### PR TITLE
feat: serialize `pd.Dataframe` as csv

### DIFF
--- a/gosling/__init__.py
+++ b/gosling/__init__.py
@@ -1,3 +1,18 @@
+import pandas as pd
+
 from gosling.schema import *
 from gosling.api import *
 from gosling.display import renderers
+
+
+@pd.api.extensions.register_dataframe_accessor("gos")  # type: ignore
+class GosAccessor:
+    def __init__(self, df: pd.DataFrame):
+        self._df = df
+
+    def csv(self, **kwargs):
+        from gosling.experimental.data import data_server
+
+        content = self._df.to_csv(index=False) or ""
+        url = data_server(content, extension="csv")
+        return dict(type="csv", url=url, **kwargs)

--- a/gosling/display.py
+++ b/gosling/display.py
@@ -127,7 +127,6 @@ class HTMLRenderer(BaseRenderer):
         return {"text/html": html}
 
 
-
 @dataclass
 class RendererRegistry:
     renderers: Dict[str, BaseRenderer] = field(default_factory=dict)

--- a/gosling/experimental/_provider.py
+++ b/gosling/experimental/_provider.py
@@ -137,7 +137,7 @@ class FileResource(Resource):
         route: Optional[str] = None,
     ):
         self.filepath = filepath
-        extension = extension or filepath.suffix.lstrip('.')
+        extension = extension or filepath.suffix.lstrip(".")
         super().__init__(
             provider=provider, headers=headers, extension=extension, route=route
         )

--- a/gosling/experimental/_provider.py
+++ b/gosling/experimental/_provider.py
@@ -137,6 +137,7 @@ class FileResource(Resource):
         route: Optional[str] = None,
     ):
         self.filepath = filepath
+        extension = extension or filepath.suffix.lstrip('.')
         super().__init__(
             provider=provider, headers=headers, extension=extension, route=route
         )

--- a/gosling/experimental/data.py
+++ b/gosling/experimental/data.py
@@ -59,7 +59,11 @@ class GoslingDataServer:
 
     def __rich_repr__(self):
         yield "resources", self._resources
-        yield "port", self.port
+        try:
+            port = self.port
+        except RuntimeError:
+            port = None
+        yield "port", port
 
 
 data_server = GoslingDataServer()

--- a/gosling/experimental/data.py
+++ b/gosling/experimental/data.py
@@ -85,7 +85,7 @@ def _create_loader(type_: str, create_ts: Optional[CreateTileset] = None):
             if fp.is_file():
                 kwargs["indexUrl"] = data_server(fp)
 
-        return dict(type=type_, url=url, **kwargs)
+        return dict(type=type_, url=str(url), **kwargs)
 
     return load
 

--- a/gosling/experimental/data.py
+++ b/gosling/experimental/data.py
@@ -1,7 +1,6 @@
 import pathlib
 from typing import Callable, Dict, Optional, Union
 
-import pandas as pd
 import gosling.experimental._tilesets as tilesets
 from gosling.experimental._provider import Provider, Resource, TilesetResource
 from gosling.utils.core import _compute_data_hash
@@ -85,17 +84,6 @@ def _create_loader(type_: str, create_ts: Optional[CreateTileset] = None):
         return dict(type=type_, url=url, **kwargs)
 
     return load
-
-
-@pd.api.extensions.register_dataframe_accessor("gos")  # type: ignore
-class GosAccessor:
-    def __init__(self, df: pd.DataFrame):
-        self._df = df
-
-    def csv(self, **kwargs):
-        content = self._df.to_csv(index=False) or ""
-        url = data_server(content, extension="csv")
-        return dict(type="csv", url=url, **kwargs)
 
 
 # re-export json data util

--- a/gosling/experimental/data.py
+++ b/gosling/experimental/data.py
@@ -1,6 +1,7 @@
 import pathlib
 from typing import Callable, Dict, Optional, Union
 
+import pandas as pd
 import gosling.experimental._tilesets as tilesets
 from gosling.experimental._provider import Provider, Resource, TilesetResource
 from gosling.utils.core import _compute_data_hash
@@ -31,7 +32,10 @@ class GoslingDataServer:
         self._resources = {}
 
     def __call__(
-        self, data: Union[pathlib.Path, tilesets.Tileset], port: Optional[int] = None
+        self,
+        data: Union[str, pathlib.Path, tilesets.Tileset],
+        port: Optional[int] = None,
+        **kwargs,
     ):
         if self._provider is None:
             self._provider = Provider(allowed_origins=["*"]).start(port=port)
@@ -40,15 +44,17 @@ class GoslingDataServer:
             self._provider.stop().start(port=port)
 
         if isinstance(data, tilesets.Tileset):
-            key = "tileset"
-            path = data.filepath
+            kwargs["tileset"] = data
+            resource_id = _hash_path(data.filepath)
+        elif isinstance(data, pathlib.Path):
+            kwargs["filepath"] = data
+            resource_id = _hash_path(data)
         else:
-            key = "filepath"
-            path = data
+            kwargs["content"] = data
+            resource_id = _compute_data_hash(data)
 
-        resource_id = _hash_path(path)
         if resource_id not in self._resources:
-            self._resources[resource_id] = self._provider.create(**{key: data})
+            self._resources[resource_id] = self._provider.create(**kwargs)
 
         return self._resources[resource_id].url
 
@@ -79,6 +85,17 @@ def _create_loader(type_: str, create_ts: Optional[CreateTileset] = None):
         return dict(type=type_, url=url, **kwargs)
 
     return load
+
+
+@pd.api.extensions.register_dataframe_accessor("gos")  # type: ignore
+class GosAccessor:
+    def __init__(self, df: pd.DataFrame):
+        self._df = df
+
+    def csv(self, **kwargs):
+        content = self._df.to_csv(index=False) or ""
+        url = data_server(content, extension="csv")
+        return dict(type="csv", url=url, **kwargs)
 
 
 # re-export json data util


### PR DESCRIPTION
Requires that `gosling.[dev]` for installation. If we can support this feature without the data-server (using the json data-type), but this would currently lead to embedding the full dataset multiple times in the chart definition becaused we don't support data references: https://github.com/gosling-lang/gosling.js/issues/508

```python
import gosling as gos # import registers `pd.Dataframe.gos` namespace
import pandas as pd

df = pd.Dataframe(...)
data = df.gos.csv(...)
gos.Track(data).mark_bar().encode(...)
```

It might be good to dig into these methods more deeply for safer serialization of dataframes: https://github.com/altair-viz/altair/blob/master/altair/utils/data.py#L178-L217