### PR TITLE
feat: add a pandas example

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           pip install .[dev]
 
       - name: Run pytest
-        run: pytest --doctest-modules gosling
+        run: pytest --ignore gosling/examples --doctest-modules gosling
 
   deploy:
     runs-on: ubuntu-latest

--- a/gosling/examples/between_link_pandas.py
+++ b/gosling/examples/between_link_pandas.py
@@ -55,8 +55,8 @@ def set_encoding(track):
     )
 
 gos.overlay(
-    set_encoding(gos.Track(data_bg)).encode(stroke=gos.Channel("second_chr:N")),
-    set_encoding(gos.Track(data_hl)).encode(stroke=gos.value("lightgray"))
+    set_encoding(gos.Track(data_bg)).encode(stroke=gos.value("lightgray")),
+    set_encoding(gos.Track(data_hl)).encode(stroke=gos.Channel("second_chr:N"))
 ).properties(
     width=600,
     height=200

--- a/gosling/examples/between_link_pandas.py
+++ b/gosling/examples/between_link_pandas.py
@@ -1,8 +1,8 @@
 """
 Between Links Using Pandas
-======
+==========================
 """
-# category: others
+# category: skip
 import gosling as gos
 import pandas as pd
 

--- a/gosling/examples/between_link_pandas.py
+++ b/gosling/examples/between_link_pandas.py
@@ -1,0 +1,63 @@
+"""
+Between Links Using Pandas
+======
+"""
+# category: others
+import gosling as gos
+import pandas as pd
+
+"""
+Data Transform Using Pandas
+"""
+df = pd.read_csv(
+    "https://raw.githubusercontent.com/vigsterkr/circos/master/data/5/segdup.txt", 
+    sep=" ",
+    header=0,
+    names=["id", "chr", "start", "end"]
+)
+
+# Use chromosome names that are interpretable in gos
+df.chr = df.chr.apply(lambda x: x.replace("hs", "chr"))
+
+# Select ids that occur exact two times
+df = df[df.groupby("id")["id"].transform("size") == 2]
+
+# Wide to long (i.e., "chr, start, end" --> "first_chr, first_start, first_end, second_chr, second_start, second_end")
+df["cumcnt"] = df.groupby("id").cumcount()
+df = pd.DataFrame(df.pivot(index="id", columns="cumcnt")[["chr", "start", "end"]].to_records())
+df = df.rename(columns={
+    "('chr', 0)": "first_chr", 
+    "('chr', 1)": "second_chr", 
+    "('start', 0)": "first_start", 
+    "('start', 1)": "second_start", 
+    "('end', 0)": "first_end", 
+    "('end', 1)": "second_end"
+})
+
+df_bg = df[(df.first_chr == 'chr1') | (df.second_chr == 'chr1')]
+df_hl = df[(df.first_chr != 'chr1') & (df.second_chr != 'chr1')]
+
+column_info = [
+    {"chromosomeField": "first_chr", "genomicFields": ["first_start", "first_end"]}, 
+    {"chromosomeField": "second_chr", "genomicFields": ["second_start", "second_end"]}
+]
+data_bg = df_bg.gos.csv(genomicFieldsToConvert=column_info)
+data_hl = df_hl.gos.csv(genomicFieldsToConvert=column_info)
+
+"""
+Encoding
+"""
+def set_encoding(track):
+    return track.mark_withinLink().encode(
+        x=gos.Channel("first_start:G"), 
+        xe=gos.Channel("second_end:G"),
+        opacity=gos.value(0.2)
+    )
+
+gos.overlay(
+    set_encoding(gos.Track(data_bg)).encode(stroke=gos.Channel("second_chr:N")),
+    set_encoding(gos.Track(data_hl)).encode(stroke=gos.value("lightgray"))
+).properties(
+    width=600,
+    height=200
+)

--- a/gosling/examples/between_link_pandas.py
+++ b/gosling/examples/between_link_pandas.py
@@ -22,7 +22,7 @@ df.chr = df.chr.apply(lambda x: x.replace("hs", "chr"))
 # Select ids that occur exact two times
 df = df[df.groupby("id")["id"].transform("size") == 2]
 
-# Wide to long (i.e., "chr, start, end" --> "first_chr, first_start, first_end, second_chr, second_start, second_end")
+# Long to wide (i.e., "chr, start, end" --> "first_chr, first_start, first_end, second_chr, second_start, second_end")
 df["cumcnt"] = df.groupby("id").cumcount()
 df = pd.DataFrame(df.pivot(index="id", columns="cumcnt")[["chr", "start", "end"]].to_records())
 df = df.rename(columns={

--- a/gosling/experimental/data.py
+++ b/gosling/experimental/data.py
@@ -1,7 +1,6 @@
 import pathlib
 from typing import Callable, Dict, Optional, Union
 
-import pandas as pd
 import gosling.experimental._tilesets as tilesets
 from gosling.experimental._provider import Provider, Resource, TilesetResource
 from gosling.utils.core import _compute_data_hash
@@ -89,17 +88,6 @@ def _create_loader(type_: str, create_ts: Optional[CreateTileset] = None):
         return dict(type=type_, url=str(url), **kwargs)
 
     return load
-
-
-@pd.api.extensions.register_dataframe_accessor("gos")  # type: ignore
-class GosAccessor:
-    def __init__(self, df: pd.DataFrame):
-        self._df = df
-
-    def csv(self, **kwargs):
-        content = self._df.to_csv(index=False) or ""
-        url = data_server(content, extension="csv")
-        return dict(type="csv", url=url, **kwargs)
 
 
 # re-export json data util

--- a/gosling/experimental/data.py
+++ b/gosling/experimental/data.py
@@ -1,6 +1,7 @@
 import pathlib
 from typing import Callable, Dict, Optional, Union
 
+import pandas as pd
 import gosling.experimental._tilesets as tilesets
 from gosling.experimental._provider import Provider, Resource, TilesetResource
 from gosling.utils.core import _compute_data_hash
@@ -88,6 +89,17 @@ def _create_loader(type_: str, create_ts: Optional[CreateTileset] = None):
         return dict(type=type_, url=str(url), **kwargs)
 
     return load
+
+
+@pd.api.extensions.register_dataframe_accessor("gos")  # type: ignore
+class GosAccessor:
+    def __init__(self, df: pd.DataFrame):
+        self._df = df
+
+    def csv(self, **kwargs):
+        content = self._df.to_csv(index=False) or ""
+        url = data_server(content, extension="csv")
+        return dict(type="csv", url=url, **kwargs)
 
 
 # re-export json data util

--- a/gosling/sphinxext/gallery.py
+++ b/gosling/sphinxext/gallery.py
@@ -112,7 +112,13 @@ def prev_this_next(
 
 
 def populate_examples():
-    return sorted(map(Example.from_file, iter_examples()), key=lambda e: e.category)
+    return sorted(
+        filter(
+            lambda e: e.category != "skip",
+            map(Example.from_file, iter_examples()),
+        ),
+        key=lambda e: e.category,
+    )
 
 
 def main(app):


### PR DESCRIPTION
<img width="615" alt="Screen Shot 2021-09-17 at 4 53 22 PM" src="https://user-images.githubusercontent.com/9922882/133854799-160ef8c0-8297-4a75-8151-258944e936f8.png">

Eventually, we can have a separate page like `local_data.html` (e.g., `pandas_dataframe.html`), and this example can be moved and used for that page. Wanted to share this example which I created during testing https://github.com/gosling-lang/gos/pull/63.

@manzt Is it possible to use pandas for documentation?