### PR TITLE
feat: add `View.save()` to render to HTML

### DIFF
--- a/gosling/api.py
+++ b/gosling/api.py
@@ -1,6 +1,8 @@
 from typing import Iterable, TypeVar, Union
+import pathlib
+
 from gosling.schema import Undefined, channels, core, mixins
-from gosling.display import renderers
+from gosling.display import renderers, spec_to_html
 import gosling.utils as utils
 
 DEFAULT_WIDTH = 800
@@ -193,6 +195,11 @@ class View(_PropertiesMixin, core.Root):
         from IPython.display import display
 
         display(self)
+
+    def save(self, path: Union[pathlib.Path, str]):
+        spec = self.to_dict()
+        with open(path, mode="w") as f:
+            f.write(spec_to_html(spec))
 
 
 # View utilities


### PR DESCRIPTION
```python
import gosling as gos

data = gos.multivec(
    url="https://resgen.io/api/v1/tileset_info/?d=UvVPeLHuRDiYA3qwFlm7xQ",
    row="base", column="position", value="count", categories=["A", "T", "G", "C"],
    start="start", end="end", binSize=16,
)

track = gos.Track(data).mark_text(textStrokeWidth=0).encode(
    y="count:Q",
    x=gos.Channel("start:G", axis="top"),
    xe="end:G",
    color=gos.Channel("base:N", domain=["A", "T", "G", "C"]),
    text="base:N",
).properties(width=725, height=180, stretch=True)

view = track.view(title="Basic Marks: Text", subtitle="Tutorial Examples")
```

```python
view.save('index.html') # writes HTML to disk
```

<img width="1237" alt="Screen Shot 2021-10-22 at 12 49 22 PM" src="https://user-images.githubusercontent.com/24403730/138493108-f0307c92-f9cf-40f3-997b-cafe4d3b6bb6.png">


