### PR TITLE
chore: rename SCHEMA_URL_TEMPLATE -> GOSLING_URL_TEMPLATE

### DIFF
--- a/gosling/schema/__init__.py
+++ b/gosling/schema/__init__.py
@@ -3,4 +3,4 @@ from .core import *
 from .channels import *
 SCHEMA_VERSION = 'v0.9.4'
 SCHEMA_URL = 'https://raw.githubusercontent.com/gosling-lang/gosling.js/v0.9.4/schema/gosling.schema.json'
-THEMES = {'excel', 'ucsc', 'light', 'washu', 'igv', 'jbrowse', 'warm', 'ggplot', 'ensembl', 'dark', 'google'}
+THEMES = {'igv', 'ensembl', 'ucsc', 'light', 'washu', 'google', 'warm', 'excel', 'ggplot', 'jbrowse', 'dark'}

--- a/gosling/schema/__init__.py
+++ b/gosling/schema/__init__.py
@@ -3,4 +3,4 @@ from .core import *
 from .channels import *
 SCHEMA_VERSION = 'v0.9.4'
 SCHEMA_URL = 'https://raw.githubusercontent.com/gosling-lang/gosling.js/v0.9.4/schema/gosling.schema.json'
-THEMES = {'igv', 'ensembl', 'ucsc', 'light', 'washu', 'google', 'warm', 'excel', 'ggplot', 'jbrowse', 'dark'}
+THEMES = {'dark', 'ensembl', 'excel', 'ggplot', 'google', 'igv', 'jbrowse', 'light', 'ucsc', 'warm', 'washu'}

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -135,17 +135,23 @@ class ValueSchemaGenerator(codegen.SchemaGenerator):
     )
 
 
-SCHEMA_URL_TEMPLATE = "https://raw.githubusercontent.com/gosling-lang/{library}/{version}/schema/{filename}"
+GOSLING_URL_TEMPLATE = "https://raw.githubusercontent.com/gosling-lang/{library}/{version}/schema/{filename}"
+
 
 def schema_class(*args, **kwargs):
     return codegen.SchemaGenerator(*args, **kwargs).schema_class()
 
 
 def schema_url(library: str, version: str):
-    return SCHEMA_URL_TEMPLATE.format(library=library, version=version, filename='gosling.schema.json')
+    return GOSLING_URL_TEMPLATE.format(
+        library=library, version=version, filename="gosling.schema.json"
+    )
+
 
 def theme_url(library: str, version: str):
-    return SCHEMA_URL_TEMPLATE.format(library=library, version=version, filename='theme.schema.json')
+    return GOSLING_URL_TEMPLATE.format(
+        library=library, version=version, filename="theme.schema.json"
+    )
 
 
 def download_schemafile(
@@ -339,9 +345,7 @@ def mark_{mark}({def_arglist}) -> T:
 '''
 
 
-def generate_mark_mixin(
-    schemafile: pathlib.Path, mark_enum: str, style_def: str
-):
+def generate_mark_mixin(schemafile: pathlib.Path, mark_enum: str, style_def: str):
     with open(schemafile, encoding="utf8") as f:
         schema = json.load(f)
 
@@ -415,7 +419,6 @@ def main(skip_download: Optional[bool] = False):
         f.write(f"SCHEMA_VERSION = {repr(version)}\n")
         f.write(f"SCHEMA_URL = {repr(schema_url(library, version))}\n")
         f.write(f"THEMES = {repr(themes)}\n")
-
 
     # Generate the core schema wrappers
     outfile = schemapath / "core.py"

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -407,7 +407,7 @@ def main(skip_download: Optional[bool] = False):
     # TODO(2021-11-01): Use same version as schema, not latest. Should be able to remove for >= v0.9.9
     with request.urlopen(theme_url(library, version="master")) as f:
         themes_schema = json.loads(f.read())
-        themes = set(themes_schema["definitions"]["ThemeType"]["enum"])
+        themes = themes_schema["definitions"]["ThemeType"]["enum"]
 
     # Generate __init__.py file
     outfile = schemapath / "__init__.py"
@@ -418,7 +418,8 @@ def main(skip_download: Optional[bool] = False):
         f.write("from .channels import *\n")
         f.write(f"SCHEMA_VERSION = {repr(version)}\n")
         f.write(f"SCHEMA_URL = {repr(schema_url(library, version))}\n")
-        f.write(f"THEMES = {repr(themes)}\n")
+        # sort themes alphabetically, change from list to set
+        f.write(f"THEMES = {sorted(themes)}\n".replace("[", "{").replace("]", "}"))
 
     # Generate the core schema wrappers
     outfile = schemapath / "core.py"


### PR DESCRIPTION
Additionally, running `tools/generate_schema_wrapper.py` currently lists the of `THEMES` in a non-deterministic order. I have edited the script to sort the themes, and change the list to set by swapping "[" with "{" brackets.