### PR TITLE
chore: show region around BRCA2 in lollipop example

### DIFF
--- a/gosling/examples/multiscale_lollipop_plot.py
+++ b/gosling/examples/multiscale_lollipop_plot.py
@@ -75,6 +75,7 @@ lolipop = gos.overlay(
     ),
     width=725,
     height=150,
+    xDomain=gos.Domain(chromosome="13", interval=[31500000, 33150000]),
 )
 
 lolipop


### PR DESCRIPTION
After:
![Screen Shot 2021-12-16 at 10 53 02 AM](https://user-images.githubusercontent.com/9922882/146404568-1d8faebd-90ed-4b4d-878a-c6773e2eff93.png)

Before:
![Screen Shot 2021-12-16 at 10 54 45 AM](https://user-images.githubusercontent.com/9922882/146404645-645ad456-fb61-4d63-be8e-b6e257070724.png)


@manzt Is there a way to locally run a documentation website after making changes?