### PR TITLE
feat: support colab for server

### DIFF
--- a/gosling/data/_provider.py
+++ b/gosling/data/_provider.py
@@ -251,8 +251,8 @@ def create_tileset_route(tileset_resources: MutableMapping[str, TilesetResource]
     return starlette.routing.Mount(
         "/api/v1",
         routes=[
-            starlette.routing.Route("/tileset_info", endpoint=tileset_info),
-            starlette.routing.Route("/tiles", endpoint=tiles),
+            starlette.routing.Route("/tileset_info/", endpoint=tileset_info),
+            starlette.routing.Route("/tiles/", endpoint=tiles),
         ],
     )
 


### PR DESCRIPTION
Fixes the tilesets routes so they work with google colab's service worker proxy.