### PR TITLE
Use extra_requires for server/optional dependencies

### DIFF
--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -6,7 +6,7 @@ Installation
 ============
 **gos** can be installed using::
 
-    $ pip install gosling
+    $ pip install 'gosling[all]'
 
 Development Install
 ===================
@@ -14,12 +14,6 @@ Development Install
 The `gos source repository`_ is available on GitHub. Once you have cloned the
 repository and installed all the above dependencies, run the following command
 from the root of the repository to install the main version of **gos**:
-
-.. code-block:: bash
-
-    $ pip install -e .
-
-To install development dependencies as well, run
 
 .. code-block:: bash
 

--- a/gosling/data/__init__.py
+++ b/gosling/data/__init__.py
@@ -1,10 +1,11 @@
 import pathlib
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import gosling.data._tilesets as tilesets
-from gosling.data._provider import Provider, Resource, TilesetResource
 from gosling.utils.core import _compute_data_hash
 
+if TYPE_CHECKING:
+    from gosling.data._provider import Provider, Resource, TilesetResource
 
 def _hash_path(path: pathlib.Path):
     return _compute_data_hash(str(path))
@@ -37,6 +38,8 @@ class GoslingDataServer:
         **kwargs,
     ):
         if self._provider is None:
+            # only try to import server dependencies when using server
+            from gosling.data._provider import Provider
             self._provider = Provider(allowed_origins=["*"]).start(port=port)
 
         if port is not None and port != self._provider.port:

--- a/gosling/data/tests/test_provider.py
+++ b/gosling/data/tests/test_provider.py
@@ -8,7 +8,7 @@ import starlette.requests
 import starlette.responses
 import starlette.routing
 
-from gosling.data import Provider, Resource, TilesetResource
+from gosling.data._provider import Provider, Resource, TilesetResource
 from gosling.data._tilesets import Tileset
 
 content = b"root content"

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,16 +20,21 @@ include_package_data = True
 install_requires =
   jsonschema>=3.0,<4.0
   jinja2
-  numpy
   pandas
+
+[options.extras_require]
+server =
   portpicker
   uvicorn
   starlette
-
-[options.extras_require]
+all =
+  gosling-widget
+  clodius
+  %(server)s
 dev =
   pytest
   requests
   sphinx
   numpydoc
   furo
+  %(server)s


### PR DESCRIPTION
Not all users will need the server implementation, along with the those dependencies. This PR adds additional `extra_requires` to the package and dynamically will try to load the server when first used by an end user.

Adds:

```bash
pip install gosling[server] # gosling + server dependencies
pip install gosling[all] # gosling + server + gosling-widget + clodius
```
