### PR TITLE
feat: add shorthand syntax option for gos.Tooltip

### DIFF
--- a/doc/user_guide/API.rst
+++ b/doc/user_guide/API.rst
@@ -35,6 +35,7 @@ Encoding Channels
    StrokeWidthValue
    Text
    TextValue
+   Tooltip
    X
    X1
    X1Value

--- a/gosling/examples/genes.py
+++ b/gosling/examples/genes.py
@@ -28,12 +28,7 @@ genes = gos.beddb(
 base = gos.Track(genes).encode(
     row=gos.Row("strand:N", domain=["+", "-"]),
     color=gos.Color("strand:N", domain=["+", "-"], range=["#7585FF", "#FF8A85"]),
-    tooltip=[
-        gos.Tooltip(field="start", type="genomic", alt="Start Position"),
-        gos.Tooltip(field="end", type="genomic", alt="End Position"),
-        gos.Tooltip(field="strand", type="nominal", alt="Strand"),
-        gos.Tooltip(field="name", type="nominal", alt="Name")
-    ]
+    tooltip=["start:G", "end:G", "strand:N", "name:N"],
 ).properties(
     title="Genes | hg38",
 )

--- a/gosling/schema/channels.py
+++ b/gosling/schema/channels.py
@@ -424,6 +424,34 @@ class TextValue(ValueChannelMixin, core.ChannelValue):
         super(TextValue, self).__init__(value=value, **kwds)
 
 
+class Tooltip(FieldChannelMixin, core.Tooltip):
+    """Tooltip schema wrapper
+
+    Mapping(required=[shorthand])
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    alt : string
+
+    field : string
+
+    format : string
+
+    type : :class:`FieldType`
+
+    """
+    _class_is_valid_at_instantiation = False
+    _encoding_name = "tooltip"
+
+    def __init__(self, shorthand=Undefined, alt=Undefined, field=Undefined, format=Undefined,
+                 type=Undefined, **kwds):
+        super(Tooltip, self).__init__(shorthand=shorthand, alt=alt, field=field, format=format,
+                                      type=type, **kwds)
+
+
 class X(FieldChannelMixin, core.X):
     """X schema wrapper
 

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -295,6 +295,8 @@ def generate_channel_wrappers(schemafile, imports=None):
     encoding_def = "SingleTrack"
     encoding = SchemaInfo(schema["definitions"][encoding_def], rootschema=schema)
 
+    from rich import print
+
     # Iterate over all properties defined on `SingleTrack` since encoding fields
     # are defined at the same level as non-encoding fields. We filter for visual
     # channel properties since they are distinguished by `ChannelValue` option.
@@ -309,8 +311,9 @@ def generate_channel_wrappers(schemafile, imports=None):
             definitions = [s.ref for s in propschema.anyOf if s.is_reference()]
             if not any("ChannelValue" in d for d in definitions):
                 definitions = []
+        elif prop == 'tooltip':
+            definitions = [propschema.items['$ref']]
         else:
-            # raise ValueError("either $ref or anyOf expected")
             definitions = []
 
         for definition in definitions:

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -292,10 +292,8 @@ def generate_channel_wrappers(schemafile, imports=None):
 
     contents.append(CHANNEL_MIXINS)
 
-    encoding_def = "SingleTrack"
+    encoding_def = "SingleTrack" # ideally we should be able to use "Encoding" type here...
     encoding = SchemaInfo(schema["definitions"][encoding_def], rootschema=schema)
-
-    from rich import print
 
     # Iterate over all properties defined on `SingleTrack` since encoding fields
     # are defined at the same level as non-encoding fields. We filter for visual


### PR DESCRIPTION
Allows for `shorthand` syntax with `gos.Tooltip`. Allows,

```diff
gos.Track(genes).encode(
    row=gos.Row("strand:N", domain=["+", "-"]),
    color=gos.Color("strand:N", domain=["+", "-"], range=["#7585FF", "#FF8A85"]),
    tooltip=[
-        gos.Tooltip(field="start", type="genomic", alt="Start Position"),
-        gos.Tooltip(field="end", type="genomic", alt="End Position"),\
-        gos.Tooltip(field="strand", type="nominal", alt="Strand"),
-        gos.Tooltip(field="name", type="nominal", alt="Name")
+        gos.Tooltip("start:G", alt="Start Position"), 
+        gos.Tooltip("end:G", alt="End Position"),
+        "strand:N", 
+        "name:N",
    ]
)
```
