### PR TITLE
refactor: use ESM import from esm.sh

### DIFF
--- a/gosling/display.py
+++ b/gosling/display.py
@@ -13,68 +13,17 @@ HTML_TEMPLATE = jinja2.Template(
 <html>
 <head>
   <style>.error { color: red; }</style>
-  <link rel="stylesheet" href="{{ higlass_css_url }}">
+  <link rel="stylesheet" href="{{ deps.css_url }}">
 </head>
 <body>
   <div id="{{ output_div }}"></div>
   <script type="module">
-
-    async function loadScript(src) {
-        return new Promise(resolve => {
-            const script = document.createElement('script');
-            script.onload = resolve;
-            script.src = src;
-            script.async = false;
-            document.head.appendChild(script);
-        });
-    }
-
-    async function loadGosling() {
-        // Manually load scripts from window namespace since requirejs might not be
-        // available in all browser environments.
-
-        // https://github.com/DanielHreben/requirejs-toggle
-        if (!window.gosling) {
-
-            // https://github.com/DanielHreben/requirejs-toggle
-            window.__requirejsToggleBackup = {
-                define: window.define,
-                require: window.require,
-                requirejs: window.requirejs,
-            };
-
-            for (const field of Object.keys(window.__requirejsToggleBackup)) {
-                window[field] = undefined;
-            }
-
-            // load dependencies sequentially
-            const sources = [
-                "{{ react_url }}",
-                "{{ react_dom_url }}",
-                "{{ pixijs_url }}",
-                "{{ higlass_js_url }}",
-                "{{ gosling_url }}",
-            ];
-
-            for (const src of sources) await loadScript(src);
-
-            // restore requirejs after scripts have loaded
-            Object.assign(window, window.__requirejsToggleBackup);
-            delete window.__requirejsToggleBackup;
-
-        }
-
-        return window.gosling;
-    };
-
-    var el = document.getElementById('{{ output_div }}');
-    var spec = {{ spec }};
-    var opt = {{ embed_options }};
-
-    loadGosling()
-        .then(gosling => gosling.embed(el, spec, opt))
-        .catch(err => {
-            el.innerHTML = `\
+    import * as gosling from "{{ deps.esm_url }}";
+    let el = document.querySelector('#{{ output_div }}');
+    let spec = {{ spec }};
+    let opts = {{ embed_options }};
+    gosling.embed(el, spec, opts).catch(err => {
+        el.innerHTML = `\
 <div class="error">
     <p>JavaScript Error: ${error.message}</p>
     <p>This usually means there's a typo in your Gosling specification. See the javascript console for the full traceback.</p>
@@ -91,13 +40,9 @@ GoslingSpec = Dict[str, Any]
 
 
 @dataclass
-class GoslingBundle:
-    react: str
-    react_dom: str
-    pixijs: str
-    higlass_js: str
-    higlass_css: str
-    gosling: str
+class GoslingDeps:
+    esm_url: str
+    css_url: str
 
 
 def get_display_dependencies(
@@ -105,15 +50,20 @@ def get_display_dependencies(
     higlass_version: str = "1.11",
     react_version: str = "17",
     pixijs_version: str = "6",
-    base_url: str = "https://unpkg.com",
-) -> GoslingBundle:
-    return GoslingBundle(
-        react=f"{ base_url }/react@{ react_version }/umd/react.production.min.js",
-        react_dom=f"{ base_url }/react-dom@{ react_version }/umd/react-dom.production.min.js",
-        pixijs=f"{ base_url }/pixi.js@{ pixijs_version }/dist/browser/pixi.min.js",
-        higlass_js=f"{ base_url }/higlass@{ higlass_version }/dist/hglib.js",
-        higlass_css=f"{ base_url }/higlass@{ higlass_version }/dist/hglib.css",
-        gosling=f"{ base_url }/gosling.js@{ gosling_version }/dist/gosling.js",
+) -> GoslingDeps:
+    base = "https://esm.sh"
+    deps = ",".join(
+        f"{name}@{version}"
+        for name, version in (
+            ("react-dom", react_version),
+            ("react", react_version),
+            ("pixi.js", pixijs_version),
+            ("higlass", higlass_version),
+        )
+    )
+    return GoslingDeps(
+        esm_url=f"{base}/gosling.js@{gosling_version}?bundle&deps={deps}",
+        css_url=f"{base}/higlass@{higlass_version}/dist/hglib.css",
     )
 
 
@@ -124,18 +74,11 @@ def spec_to_html(
     **kwargs,
 ):
     embed_options = embed_options or dict(padding=0, theme=themes.get())
-    deps = get_display_dependencies(**kwargs)
-
     return HTML_TEMPLATE.render(
         spec=json.dumps(spec),
         embed_options=json.dumps(embed_options),
         output_div=output_div,
-        react_url=deps.react,
-        react_dom_url=deps.react_dom,
-        pixijs_url=deps.pixijs,
-        higlass_js_url=deps.higlass_js,
-        higlass_css_url=deps.higlass_css,
-        gosling_url=deps.gosling,
+        deps=get_display_dependencies(**kwargs),
     )
 
 

--- a/gosling/sphinxext/plot.py
+++ b/gosling/sphinxext/plot.py
@@ -15,11 +15,10 @@ TEMPLATE = jinja2.Template(
 <div id="{{ div_id }}">
 <script>
   document.addEventListener("DOMContentLoaded", function(event) {
-      var spec = {{ spec }};
+      let spec = {{ spec }};
+      let el = document.querySelector('#{{ div_id }}');
+      gosling.embed(el, spec, { padding: 0 }).catch(console.error);
       console.log(spec);
-      var opt = { padding: 0 };
-      var el = document.querySelector('#{{ div_id }}');
-      gosling.embed(el, spec, opt).catch(console.err);
   });
 </script>
 </div>
@@ -113,22 +112,19 @@ def depart_gosling_plot(self, node):
 
 
 def builder_inited(app):
-    app.add_css_file(app.config.higlass_css_url)
-    app.add_js_file(app.config.react_url)
-    app.add_js_file(app.config.reactdom_url)
-    app.add_js_file(app.config.pixi_url)
-    app.add_js_file(app.config.higlass_js_url)
-    app.add_js_file(app.config.gosling_url)
+    app.add_css_file(app.config.css_url)
+    # inline script that adds `gosling` global
+    app.add_js_file(
+        filename=None,
+        type="module",
+        body=f"import * as gosling from '{app.config.esm_url}';globalThis.gosling = gosling;",
+    )
 
 
 def setup(app):
     deps = get_display_dependencies()
-    app.add_config_value("react_url", deps.react, "html")
-    app.add_config_value("reactdom_url", deps.react_dom, "html")
-    app.add_config_value("pixi_url", deps.pixijs, "html")
-    app.add_config_value("higlass_js_url", deps.higlass_js, "html")
-    app.add_config_value("higlass_css_url", deps.higlass_css, "html")
-    app.add_config_value("gosling_url", deps.gosling, "html")
+    app.add_config_value("esm_url", deps.esm_url, "html")
+    app.add_config_value("css_url", deps.css_url, "html")
 
     app.add_directive("gosling-plot", GoslingPlotDirective)
     app.add_node(gosling_plot, html=(html_visit_gosling_plot, depart_gosling_plot))


### PR DESCRIPTION
A better implementation of #98.

> Rather than (painfully) dealing with global module systems in various runtimes (e.g., requirejs), this PR uses a scoped ESM import for gosling from esm.sh, an ESM only cdn.

> These URLs aren't as stable as unpkg, but the imports should work more consistently.
