### PR TITLE
chore: use width/height defaults from gosling.js

### DIFF
--- a/gosling/api.py
+++ b/gosling/api.py
@@ -5,8 +5,6 @@ import gosling.display as display
 import gosling.utils as utils
 from gosling.schema import Undefined, channels, core, mixins
 
-DEFAULT_WIDTH = 800
-DEFAULT_HEIGHT = 180
 DEFAULT_MARK = "bar"
 
 T = TypeVar("T")
@@ -251,8 +249,6 @@ class Track(
     def __init__(self, data=Undefined, **kwargs):
         super().__init__(
             data=data,
-            width=kwargs.pop("width", DEFAULT_WIDTH),
-            height=kwargs.pop("height", DEFAULT_HEIGHT),
             mark=kwargs.pop("mark", DEFAULT_MARK),
             **kwargs,
         )
@@ -265,24 +261,7 @@ class Track(
 
 def overlay(*tracks: Union[Track, View], **kwargs) -> View:
     """Compose an overlaid view from multiple tracks or overliad tracks"""
-    # Overlay requires a `width` and `height`. Check if provided as kwargs, otherwise
-    # eagerly grab the width/height from the tracks, otherwise use defaults.
-    width = kwargs.pop(
-        "width", next((t.width for t in tracks if t.width != Undefined), DEFAULT_WIDTH)
-    )
-
-    height = kwargs.pop(
-        "height",
-        next((t.height for t in tracks if t.height != Undefined), DEFAULT_HEIGHT),
-    )
-
-    # TODO: Gosling.js doesn't respect the parent width/height if defined in children.
-    # This is a hack to ensure the children respect the view-level config.
-    tracks = tuple(t.properties(width=Undefined, height=Undefined) for t in tracks)
-
-    return View(
-        alignment="overlay", tracks=tracks, width=width, height=height, **kwargs
-    )
+    return View(alignment="overlay", tracks=tracks, **kwargs)
 
 
 def stack(*tracks: Union[Track, View], **kwargs) -> View:

--- a/gosling/examples/circos.py
+++ b/gosling/examples/circos.py
@@ -53,7 +53,7 @@ link_base = gos.Track(segdup).mark_withinLink().encode(
     x1="p2:G",
     x1e="P2_2:G",
     opacity=gos.value(0.4)
-).properties(width=WIDTH, height=300)
+)
 
 colors = ["#E79F00", "#029F73", "#0072B2", "#CB7AA7", "#D45E00", "#57B4E9", "#EFE441"]
 

--- a/gosling/tests/test_api.py
+++ b/gosling/tests/test_api.py
@@ -130,12 +130,10 @@ def test_visibilities(basic_track: gos.Track) -> None:
 
 
 def test_track_composition(basic_track: gos.Track) -> None:
-    view = gos.overlay(basic_track.properties(width=500, height=10), basic_track)
+    view = gos.overlay(basic_track, basic_track)
     assert isinstance(view, gos.View)
     assert view.alignment == "overlay"
     # uses width and height from first track
-    assert view.width == 500
-    assert view.height == 10
     assert len(view.tracks) == 2
 
     # override w/h at view-level
@@ -149,9 +147,6 @@ def test_track_composition(basic_track: gos.Track) -> None:
     assert view.width == 60
     assert view.height == 60
     assert len(view.tracks) == 3
-    for track in view.tracks:
-        assert track.width == gos.Undefined
-        assert track.height == gos.Undefined
 
     view = gos.stack(
         basic_track.properties(width=50, height=50),


### PR DESCRIPTION
Defers to Gosling.js to decide defaults for `width` and `height`: https://github.com/gosling-lang/gosling.js/pull/779
