### PR TITLE
chore: make GIF responsive in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See the [Documentation Site](https://gosling-lang.github.io/gos) for more inform
 
 ## Example
 
-<img src="https://github.com/gosling-lang/gos/raw/main/doc/_static/example.gif" alt="Gosling visualization" width="800" />
+<img src="https://github.com/gosling-lang/gos/raw/main/doc/_static/example.gif" alt="Gosling visualization"/>
 
 ```python
 import gosling as gos


### PR DESCRIPTION
To fix an issue that the large GIF image makes the other contents of the README.md too small on smaller screens, like smartphones.

The repository viewed on my iPhone currently:

![Screen Shot 2022-08-22 at 13 47 06](https://user-images.githubusercontent.com/9922882/185986107-a782ea22-f17e-4117-9394-9e57b003c164.png)

