### PR TITLE
chore: add chr prefix to examples

### DIFF
--- a/gosling/examples/area_chart.py
+++ b/gosling/examples/area_chart.py
@@ -13,7 +13,7 @@ data = gos.multivec(
     categories=["sample 1"],
 )
 
-domain = gos.GenomicDomain(chromosome="1", interval=[2000500, 3000500])
+domain = gos.GenomicDomain(chromosome="chr1", interval=[2000500, 3000500])
 
 track = gos.Track(data).mark_area().encode(
     x=gos.X("position:G", domain=domain, axis="bottom"),

--- a/gosling/examples/brushing_and_linking.py
+++ b/gosling/examples/brushing_and_linking.py
@@ -17,12 +17,12 @@ base = gos.Track(data).encode(y="peak:Q").properties(width=800, height=200)
 
 top =  gos.overlay(
     base.mark_line().encode(
-        x=gos.X("position:G", domain=gos.GenomicDomain(chromosome="1"), axis="top")
+        x=gos.X("position:G", domain=gos.GenomicDomain(chromosome="chr1"), axis="top")
     ),
     base.mark_brush().encode(
         x=gos.X(
             "position:G",
-            domain=gos.GenomicDomain(chromosome="1"),
+            domain=gos.GenomicDomain(chromosome="chr1"),
             axis="top",
             linkingId="linking-with-brush"
         ),
@@ -33,7 +33,7 @@ top =  gos.overlay(
 bottom = base.mark_line(background="steelBlue", backgroundOpacity=0.1).encode(
     x=gos.X(
         "position:G",
-        domain=gos.GenomicDomain(chromosome="1", interval=[200000000, 220000000]),
+        domain=gos.GenomicDomain(chromosome="chr1", interval=[200000000, 220000000]),
         axis="top",
         linkingId="linking-with-brush",
     )

--- a/gosling/examples/comparative_matrices.py
+++ b/gosling/examples/comparative_matrices.py
@@ -153,7 +153,7 @@ right = gos.View(views=[left_matrix, right_matrix], spacing=30)
 gos.horizontal(left, right).properties(
     title="Matrix Visualization",
     subtitle="Comparison of Micro-C and Hi-C for HFFc6 Cells",
-    xDomain=gos.GenomicDomain(chromosome="7", interval=[77700000, 81000000]),
+    xDomain=gos.GenomicDomain(chromosome="chr7", interval=[77700000, 81000000]),
     spacing=1,
     linkingId="-"
 )

--- a/gosling/examples/corces.py
+++ b/gosling/examples/corces.py
@@ -148,6 +148,6 @@ tracks = [
 # COMPOSE
 
 gos.vertical(
-    gos.View(layout="linear", tracks=[ideogram], centerRadius=0.8, xDomain=gos.GenomicDomain(chromosome="3")),
-    gos.View(tracks=tracks, linkingId="detail", xDomain=gos.GenomicDomain(chromosome="3", interval=[52168000, 52890000])),
+    gos.View(layout="linear", tracks=[ideogram], centerRadius=0.8, xDomain=gos.GenomicDomain(chromosome="chr3")),
+    gos.View(tracks=tracks, linkingId="detail", xDomain=gos.GenomicDomain(chromosome="chr3", interval=[52168000, 52890000])),
 )

--- a/gosling/examples/genes.py
+++ b/gosling/examples/genes.py
@@ -98,7 +98,7 @@ gos.overlay(
 ).properties(
     width=725, height=100,
     title="Gene Annotation",
-    xDomain=gos.GenomicDomain(chromosome="1", interval=[103400000, 103700000]),
+    xDomain=gos.GenomicDomain(chromosome="chr1", interval=[103400000, 103700000]),
     assembly="hg38",
     layout="linear",
     centerRadius=0.7,

--- a/gosling/examples/ideograms.py
+++ b/gosling/examples/ideograms.py
@@ -86,11 +86,11 @@ def ideogram_with_bars(chromosome: str, width: int):
 Composition
 """
 gos.parallel(
-    ideogram_with_bars("1", 1000),
-    ideogram_with_bars("2", 970),
-    ideogram_with_bars("3", 800),
-    ideogram_with_bars("4", 770),
-    ideogram_with_bars("5", 740)
+    ideogram_with_bars("chr1", 1000),
+    ideogram_with_bars("chr2", 970),
+    ideogram_with_bars("chr3", 800),
+    ideogram_with_bars("chr4", 770),
+    ideogram_with_bars("chr5", 740)
 ).properties(
     static=True
 )

--- a/gosling/examples/line_chart.py
+++ b/gosling/examples/line_chart.py
@@ -14,7 +14,7 @@ data = gos.multivec(
     binSize=5,
 )
 
-domain = gos.GenomicDomain(chromosome="1", interval=[1, 30005000])
+domain = gos.GenomicDomain(chromosome="chr1", interval=[1, 30005000])
 
 track = gos.Track(data).mark_line().encode(
     x=gos.X("position:G", domain=domain, axis="bottom"),

--- a/gosling/examples/multiscale_lollipop_plot.py
+++ b/gosling/examples/multiscale_lollipop_plot.py
@@ -75,7 +75,7 @@ lolipop = gos.overlay(
     ),
     width=725,
     height=150,
-    xDomain=gos.GenomicDomain(chromosome="13", interval=[31500000, 33150000]),
+    xDomain=gos.GenomicDomain(chromosome="chr13", interval=[31500000, 33150000]),
 )
 
 lolipop

--- a/gosling/examples/overview_detail.py
+++ b/gosling/examples/overview_detail.py
@@ -79,8 +79,8 @@ def detail(background, linkingId, legend, chromosome):
     ).properties(width=245, height=150)
 
 details = gos.horizontal(
-    detail("blue", "detail-1", legend=False, chromosome="5"),
-    detail("red", "detail-2", legend=True, chromosome="16"),
+    detail("blue", "detail-1", legend=False, chromosome="chr5"),
+    detail("red", "detail-2", legend=True, chromosome="chr16"),
     spacing=10,
 )
 

--- a/gosling/examples/point_plot.py
+++ b/gosling/examples/point_plot.py
@@ -14,7 +14,7 @@ data = gos.multivec(
     binSize=5,
 )
 
-domain = gos.GenomicDomain(chromosome="1", interval=[1, 30005000])
+domain = gos.GenomicDomain(chromosome="chr1", interval=[1, 30005000])
 
 track = gos.Track(data).mark_point().encode(
     x=gos.X("position:G", domain=domain, axis="bottom"),


### PR DESCRIPTION
Changed chromosome names in the examples to use `chr` prefix (e.g., `1` --> `chr1`) since the next version of Gosling will let ones use exact chromosome names (https://github.com/gosling-lang/gosling.js/pull/796).