### PR TITLE
feat: add PluginRegistry with entry_points hook

### DIFF
--- a/gosling/__init__.py
+++ b/gosling/__init__.py
@@ -19,7 +19,7 @@ from gosling.data import (
     multivec,
     vector,
 )
-from gosling.display import themes
+from gosling.display import themes, renderers
 
 
 @pd.api.extensions.register_dataframe_accessor("gos")  # type: ignore

--- a/gosling/api.py
+++ b/gosling/api.py
@@ -184,8 +184,8 @@ class View(_PropertiesMixin, core.Root):
     """Create a basic Gosling View."""
 
     def _repr_mimebundle_(self, include=None, exclude=None):
-        dct = self.to_dict()
-        return display.html_renderer(dct)
+        render = display.renderers.get()
+        return render(self.to_dict())
 
     def display(self):
         """Render top-level chart using IPython.display."""

--- a/gosling/plugin_registry.py
+++ b/gosling/plugin_registry.py
@@ -1,0 +1,142 @@
+# derived from https://github.com/altair-viz/altair/blob/8a8642b2e7eeee3b914850a8f7aacd53335302d9/altair/utils/plugin_registry.py
+from typing import TypeVar, Any, Generic, Dict, Union, List, cast
+import sys
+import functools
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
+
+PluginType = TypeVar("PluginType")
+
+
+class ActivePlugin(Generic[PluginType]):
+    def __init__(self, name: str, plugin: PluginType, options: Dict[str, Any]) -> None:
+        self.name = name
+        self._plugin = plugin
+        self.options = options
+
+    @functools.cached_property
+    def plugin(self) -> PluginType:
+        if self.options and callable(self._plugin):
+            # apply options if provided
+            return cast(PluginType, functools.partial(self._plugin, **self.options))
+        return self._plugin
+
+
+class PluginEnabler(Generic[PluginType]):
+    """Context manager for enabling plugins
+    This object lets you use enable() as a context manager to
+    temporarily enable a given plugin::
+        with plugins.enable('name'):
+            do_something()  # 'name' plugin temporarily enabled
+        # plugins back to original state
+    """
+
+    def __init__(
+        self,
+        registry: "PluginRegistry[PluginType]",
+        reset: Union[None, ActivePlugin[PluginType]],
+    ):
+        self.registry = registry
+        self.reset = reset
+
+    def __enter__(self) -> "PluginEnabler[PluginType]":
+        return self
+
+    def __exit__(self, *args, **kwargs) -> None:
+        self.registry._active = self.reset
+
+    def __repr__(self) -> str:
+        return "{}.enable({!r})".format(
+            self.registry.__class__.__name__, self.registry.active
+        )
+
+
+class PluginRegistry(Generic[PluginType]):
+    """A registry for plugins.
+
+    This is a plugin registry that allows plugins to be loaded/registered
+    in two ways:
+
+    1. Through an explicit call to ``.register(name, value)``.
+    2. By looking for other Python packages that are installed and provide
+       a setuptools entry point group.
+    When you create an instance of this class, provide the name of the
+    entry point group to use::
+
+        reg = PluginRegister('my_entrypoint_group')
+
+    """
+
+    def __init__(self, entry_point_group: str = ""):
+        self.entry_point_group = entry_point_group
+        self._active = None  # type: Union[None, ActivePlugin[PluginType]]
+        self._plugins = {}  # type: Dict[str, PluginType]
+
+    def register(
+        self, name: str, value: Union[PluginType, None]
+    ) -> Union[PluginType, None]:
+        """Register a plugin by name and value.
+
+        This method is used for explicit registration of a plugin and shouldn't be
+        used to manage entry point managed plugins, which are auto-loaded.
+
+        Parameters
+        ==========
+        name: str
+            The name of the plugin.
+        value: PluginType or None
+            The actual plugin object to register or None to unregister that plugin.
+
+        Returns
+        =======
+        plugin: PluginType or None
+            The plugin that was registered or unregistered.
+        """
+        if value is None:
+            return self._plugins.pop(name, None)
+        else:
+            self._plugins[name] = value
+            return value
+
+    def names(self) -> List[str]:
+        """List the names of the registered and entry points plugins."""
+        exts = list(self._plugins.keys())
+        exts.extend(e.name for e in entry_points(group=self.entry_point_group))
+        return sorted(set(exts))
+
+    def enable(self, name: Union[None, str] = None, **options):
+        name = name or self.active
+        if name is None:
+            raise ValueError("Must first enable a plugin before re-enabling.")
+        return PluginEnabler(self, reset=self._enable(name, **options))
+
+    def _enable(self, name: str, **options):
+        if name not in self._plugins:
+            exts = entry_points(group=self.entry_point_group, name=name)
+            # Only load if we find an entrypoint
+            if len(exts) > 0:
+                assert len(exts) == 1, f"Conflicting entry-point '{name}'"
+                ext = tuple(exts)[0]
+                self.register(name, cast(PluginType, ext.load()))
+        prev = self._active
+        self._active = ActivePlugin(name, self._plugins[name], options)
+        return prev
+
+    @property
+    def active(self):
+        return "" if self._active is None else self._active.name
+
+    @property
+    def options(self):
+        return {} if self._active is None else self._active.options
+
+    def get(self):
+        return self._active and self._active.plugin
+
+    def __repr__(self) -> str:
+        return "{}(active={!r}, registered={!r})" "".format(
+            self.__class__.__name__, self.active, self.names()
+        )

--- a/gosling/renderer.py
+++ b/gosling/renderer.py
@@ -1,2 +1,0 @@
-def main():
-    print('it worked!')

--- a/gosling/renderer.py
+++ b/gosling/renderer.py
@@ -1,0 +1,2 @@
+def main():
+    print('it worked!')

--- a/gosling/tests/test_plugin_registry.py
+++ b/gosling/tests/test_plugin_registry.py
@@ -1,0 +1,92 @@
+from gosling.plugin_registry import PluginRegistry
+from typing import Callable
+
+
+class TypedCallableRegistry(PluginRegistry[Callable[[int], int]]):
+    ...
+
+
+class GeneralCallableRegistry(PluginRegistry):
+    ...
+
+
+def test_plugin_registry():
+    plugins = TypedCallableRegistry()
+
+    assert plugins.names() == []
+    assert plugins.active == ""
+    assert plugins.get() is None
+    assert repr(plugins) == "TypedCallableRegistry(active='', registered=[])"
+
+    plugins.register("new_plugin", lambda x: x**2)
+    assert plugins.names() == ["new_plugin"]
+    assert plugins.active == ""
+    assert plugins.get() is None
+    assert repr(plugins) == (
+        "TypedCallableRegistry(active='', " "registered=['new_plugin'])"
+    )
+
+    plugins.enable("new_plugin")
+    assert plugins.names() == ["new_plugin"]
+    assert plugins.active == "new_plugin"
+    assert plugins.get()(3) == 9 # type: ignore
+    assert repr(plugins) == (
+        "TypedCallableRegistry(active='new_plugin', " "registered=['new_plugin'])"
+    )
+
+
+def test_plugin_registry_extra_options():
+    plugins = GeneralCallableRegistry()
+
+    plugins.register("metadata_plugin", lambda x, p=2: x**p)
+    plugins.enable("metadata_plugin")
+    assert plugins.get()(3) == 9 # type: ignore
+
+    plugins.enable("metadata_plugin", p=3)
+    assert plugins.active == "metadata_plugin"
+    assert plugins.get()(3) == 27 # type: ignore
+
+    # enabling without changing name
+    plugins.enable(p=2)
+    assert plugins.active == "metadata_plugin"
+    assert plugins.get()(3) == 9 # type: ignore
+
+
+def test_plugin_registry_context():
+    plugins = GeneralCallableRegistry()
+
+    plugins.register("default", lambda x, p=2: x**p)
+
+    # At first there is no plugin enabled
+    assert plugins.active == ""
+    assert plugins.options == {}
+
+    # Make sure the context is set and reset correctly
+    with plugins.enable("default", p=6):
+        assert plugins.active == "default"
+        assert plugins.options == {"p": 6}
+
+    assert plugins.active == ""
+    assert plugins.options == {}
+
+    # Make sure the context is reset even if there is an error
+    try:
+        with plugins.enable("default", p=6):
+            assert plugins.active == "default"
+            assert plugins.options == {"p": 6}
+            raise ValueError()
+    except ValueError:
+        pass
+
+    assert plugins.active == ""
+    assert plugins.options == {}
+
+    # Enabling without specifying name uses current name
+    plugins.enable("default", p=2)
+
+    with plugins.enable(p=6):
+        assert plugins.active == "default"
+        assert plugins.options == {"p": 6}
+
+    assert plugins.active == "default"
+    assert plugins.options == {"p": 2}


### PR DESCRIPTION
This PR adds a pluggable registry to extend rendering behavior via end user code. This will allow users to write their own renderers (or themes) in Python and override the default behavior.

Both `gos.renderers` and `gos.themes` are instances of `PluginRegistry`. 

### Usage

Users can register and enable their own renderers manually. As a reminder, a renderer is any function that accepts a Gosling specification as a Python dict, and returns a Python dict in Jupyter’s [MIME Bundle format](https://jupyter-client.readthedocs.io/en/stable/messaging.html#display-data)

```python
def my_custom_renderer(spec: dict) -> dict:
    ...
```

```python
import gosling as gos

vis = gos.Track(...).encode(...).view()

# add a custom renderer explicity
gos.renderers.register("my-renderer", my_custom_renderer)

# enable the renderer for the workflow
gos.renderers.enable("my-renderer")

# automatically use renderer
vis
```

and manually switch back to the default,

```python
# reenable
gos.renderers.enable("default") # switch back to normal
vis # uses the register renderer
```

or alternatively they can enable plugins in a controlled manner

```python
with gos.themes.enable("dark"):
    vis.save("index.html") # dark theme just enabled for this block

gos.themes.active # ""
```

### Automatic registration for renderers & themes in third-party packages

While the above is nice for many situations, we also want to enable third-party libraries the ability to implement plugins and have those automatically enabled for users.

For example, let's say I implement a custom HTML renderer for gos that I want to share with a colleague. Ideally one could just pip install a package and use this with Gos, i.e.,

```bash
pip install gosling[all]
pip install custom-gosling-renderer
```

```python
import gosling as gos
# automatically discovered
gos.renderers.names() # ['default', 'custom-gosling-renderer']
gos.renderers.enable('custom-gosling-renderer')
```

This is exactly what this PR supports. Package authors need to add an entrypoint to their `setup.cfg` or `setup.py` with the custom group name, and they will be discoverred automatically by the `PluginRegistry`.

### example

```python
# gosling_json_renderer/__init__.py
import json

def main(spec, **kwargs):
	return json.dumps(spec, **kwargs)
```

```python
# setup.cfg
[metadata]
name = gosling-json-renderer

[options.entry_points]
gosling.renderer =
  my-json-renderer = gosling_json_renderer:main
```

```
pip install -e .
```

```python
import gosling as gos
gos.renderers.names() # ['default', 'my-json-renderer']
```