### PR TITLE
feat: v0.9.28

### DIFF
--- a/gosling/display.py
+++ b/gosling/display.py
@@ -91,7 +91,7 @@ class GoslingBundle:
 
 def get_display_dependencies(
     gosling_version: str = SCHEMA_VERSION.lstrip("v"),
-    higlass_version: str = "1.11",
+    higlass_version: str = "~1.11",
     react_version: str = "17",
     pixijs_version: str = "6",
     base_url: str = "https://unpkg.com",

--- a/gosling/schema/__init__.py
+++ b/gosling/schema/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from .core import *
 from .channels import *
-SCHEMA_VERSION = 'v0.9.23'
-SCHEMA_URL = 'https://raw.githubusercontent.com/gosling-lang/gosling.js/v0.9.23/schema/gosling.schema.json'
+SCHEMA_VERSION = 'v0.9.28'
+SCHEMA_URL = 'https://raw.githubusercontent.com/gosling-lang/gosling.js/v0.9.28/schema/gosling.schema.json'
 THEMES = {'dark', 'ensembl', 'excel', 'ggplot', 'google', 'igv', 'jbrowse', 'light', 'ucsc', 'warm', 'washu'}

--- a/gosling/schema/core.py
+++ b/gosling/schema/core.py
@@ -1012,7 +1012,7 @@ class OneOfFilter(FilterTransform):
 
     field : string
         A filter is applied based on the values of the specified data field
-    oneOf : anyOf(List(string), List(float))
+    oneOf : List(anyOf(string, float, None))
         Check whether the value is an element in the provided list.
     type : string
 
@@ -1748,7 +1748,7 @@ class Style(GoslingSchema):
     linkMinHeight : float
         The minimum height of `withinLink` and `betweenLink` marks. Unit is a percentagle.
         __Default__: `0.5`
-    linkStyle : enum('elliptical', 'circular', 'straight', 'experimentalEdgeBundling')
+    linkStyle : enum('elliptical', 'circular', 'straight')
         The style of `withinLink` and `betweenLink` marks. __Default__: `'circular'`
         `'elliptical'` will be used as a default option.
     matrixExtent : enum('full', 'upper-right', 'lower-left')
@@ -1775,6 +1775,9 @@ class Style(GoslingSchema):
     textStrokeWidth : float
         Specify the stroke width of `text` marks. Can also be specified using the
         `strokeWidth` channel option of `text` marks.
+    withinLinkVerticalLines : boolean
+        Whether to show vertical lines that connect to the baseline (axis) when `y` and `ye`
+        are both used. __Default__: `false`
     """
     _schema = {'$ref': '#/definitions/Style'}
     _rootschema = GoslingSchema._rootschema
@@ -1785,7 +1788,8 @@ class Style(GoslingSchema):
                  linePattern=Undefined, linkConnectionType=Undefined, linkMinHeight=Undefined,
                  linkStyle=Undefined, matrixExtent=Undefined, mouseOver=Undefined, outline=Undefined,
                  outlineWidth=Undefined, select=Undefined, textAnchor=Undefined, textFontSize=Undefined,
-                 textFontWeight=Undefined, textStroke=Undefined, textStrokeWidth=Undefined, **kwds):
+                 textFontWeight=Undefined, textStroke=Undefined, textStrokeWidth=Undefined,
+                 withinLinkVerticalLines=Undefined, **kwds):
         super(Style, self).__init__(align=align, background=background,
                                     backgroundOpacity=backgroundOpacity, brush=brush, curve=curve,
                                     dashed=dashed, dx=dx, dy=dy, enableSmoothPath=enableSmoothPath,
@@ -1795,7 +1799,8 @@ class Style(GoslingSchema):
                                     matrixExtent=matrixExtent, mouseOver=mouseOver, outline=outline,
                                     outlineWidth=outlineWidth, select=select, textAnchor=textAnchor,
                                     textFontSize=textFontSize, textFontWeight=textFontWeight,
-                                    textStroke=textStroke, textStrokeWidth=textStrokeWidth, **kwds)
+                                    textStroke=textStroke, textStrokeWidth=textStrokeWidth,
+                                    withinLinkVerticalLines=withinLinkVerticalLines, **kwds)
 
 
 class SvTypeTransform(DataTransform):

--- a/gosling/schema/gosling-schema.json
+++ b/gosling/schema/gosling-schema.json
@@ -1073,6 +1073,11 @@
                       "$ref": "#/definitions/MouseEventsDeep"
                     }
                   ]
+                },
+                "performanceMode": {
+                  "default": false,
+                  "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                  "type": "boolean"
                 }
               },
               "type": "object"
@@ -1219,6 +1224,11 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
                           }
                         },
                         "type": "object"
@@ -1829,6 +1839,11 @@
                       "$ref": "#/definitions/MouseEventsDeep"
                     }
                   ]
+                },
+                "performanceMode": {
+                  "default": false,
+                  "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                  "type": "boolean"
                 }
               },
               "type": "object"
@@ -1975,6 +1990,11 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
                           }
                         },
                         "type": "object"
@@ -2638,6 +2658,11 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
                           }
                         },
                         "type": "object"
@@ -3723,21 +3748,15 @@
           "type": "boolean"
         },
         "oneOf": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "items": {
-                "type": "number"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "Check whether the value is an element in the provided list."
+          "description": "Check whether the value is an element in the provided list.",
+          "items": {
+            "type": [
+              "string",
+              "number",
+              "null"
+            ]
+          },
+          "type": "array"
         },
         "type": {
           "const": "filter",
@@ -3852,6 +3871,11 @@
                   "$ref": "#/definitions/MouseEventsDeep"
                 }
               ]
+            },
+            "performanceMode": {
+              "default": false,
+              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+              "type": "boolean"
             }
           },
           "type": "object"
@@ -3967,6 +3991,11 @@
                         "$ref": "#/definitions/MouseEventsDeep"
                       }
                     ]
+                  },
+                  "performanceMode": {
+                    "default": false,
+                    "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                    "type": "boolean"
                   }
                 },
                 "type": "object"
@@ -4529,6 +4558,11 @@
                   "$ref": "#/definitions/MouseEventsDeep"
                 }
               ]
+            },
+            "performanceMode": {
+              "default": false,
+              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+              "type": "boolean"
             }
           },
           "type": "object"
@@ -4888,6 +4922,11 @@
                   "$ref": "#/definitions/MouseEventsDeep"
                 }
               ]
+            },
+            "performanceMode": {
+              "default": false,
+              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+              "type": "boolean"
             }
           },
           "type": "object"
@@ -5003,6 +5042,11 @@
                         "$ref": "#/definitions/MouseEventsDeep"
                       }
                     ]
+                  },
+                  "performanceMode": {
+                    "default": false,
+                    "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                    "type": "boolean"
                   }
                 },
                 "type": "object"
@@ -5707,6 +5751,11 @@
                   "$ref": "#/definitions/MouseEventsDeep"
                 }
               ]
+            },
+            "performanceMode": {
+              "default": false,
+              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+              "type": "boolean"
             }
           },
           "type": "object"
@@ -6060,6 +6109,11 @@
                       "$ref": "#/definitions/MouseEventsDeep"
                     }
                   ]
+                },
+                "performanceMode": {
+                  "default": false,
+                  "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                  "type": "boolean"
                 }
               },
               "type": "object"
@@ -6202,6 +6256,11 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
                           }
                         },
                         "type": "object"
@@ -6809,6 +6868,11 @@
                       "$ref": "#/definitions/MouseEventsDeep"
                     }
                   ]
+                },
+                "performanceMode": {
+                  "default": false,
+                  "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                  "type": "boolean"
                 }
               },
               "type": "object"
@@ -6951,6 +7015,11 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
                           }
                         },
                         "type": "object"
@@ -7607,6 +7676,11 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
                           }
                         },
                         "type": "object"
@@ -8325,8 +8399,7 @@
           "enum": [
             "elliptical",
             "circular",
-            "straight",
-            "experimentalEdgeBundling"
+            "straight"
           ],
           "type": "string"
         },
@@ -8381,6 +8454,10 @@
         "textStrokeWidth": {
           "description": "Specify the stroke width of `text` marks. Can also be specified using the `strokeWidth` channel option of `text` marks.",
           "type": "number"
+        },
+        "withinLinkVerticalLines": {
+          "description": "Whether to show vertical lines that connect to the baseline (axis) when `y` and `ye` are both used. __Default__: `false`",
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/gosling/schema/mixins.py
+++ b/gosling/schema/mixins.py
@@ -16,7 +16,7 @@ class MarkMethodMixin(object):
                    linkStyle=Undefined, matrixExtent=Undefined, mouseOver=Undefined, outline=Undefined,
                    outlineWidth=Undefined, select=Undefined, textAnchor=Undefined,
                    textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                   textStrokeWidth=Undefined, **kwds) -> T:
+                   textStrokeWidth=Undefined, withinLinkVerticalLines=Undefined, **kwds) -> T:
         """Set the track's mark to 'point'
     
         For information on additional arguments, see :class:`Style`
@@ -29,7 +29,8 @@ class MarkMethodMixin(object):
                     linkStyle=linkStyle, matrixExtent=matrixExtent, mouseOver=mouseOver,
                     outline=outline, outlineWidth=outlineWidth, select=select, textAnchor=textAnchor,
                     textFontSize=textFontSize, textFontWeight=textFontWeight, textStroke=textStroke,
-                    textStrokeWidth=textStrokeWidth, **kwds)
+                    textStrokeWidth=textStrokeWidth, withinLinkVerticalLines=withinLinkVerticalLines,
+                    **kwds)
         copy = self.copy()
         copy.mark = "point"
         if any(val is not Undefined for val in kwds.values()):
@@ -43,7 +44,7 @@ class MarkMethodMixin(object):
                   linkStyle=Undefined, matrixExtent=Undefined, mouseOver=Undefined, outline=Undefined,
                   outlineWidth=Undefined, select=Undefined, textAnchor=Undefined,
                   textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                  textStrokeWidth=Undefined, **kwds) -> T:
+                  textStrokeWidth=Undefined, withinLinkVerticalLines=Undefined, **kwds) -> T:
         """Set the track's mark to 'line'
     
         For information on additional arguments, see :class:`Style`
@@ -56,7 +57,8 @@ class MarkMethodMixin(object):
                     linkStyle=linkStyle, matrixExtent=matrixExtent, mouseOver=mouseOver,
                     outline=outline, outlineWidth=outlineWidth, select=select, textAnchor=textAnchor,
                     textFontSize=textFontSize, textFontWeight=textFontWeight, textStroke=textStroke,
-                    textStrokeWidth=textStrokeWidth, **kwds)
+                    textStrokeWidth=textStrokeWidth, withinLinkVerticalLines=withinLinkVerticalLines,
+                    **kwds)
         copy = self.copy()
         copy.mark = "line"
         if any(val is not Undefined for val in kwds.values()):
@@ -70,7 +72,7 @@ class MarkMethodMixin(object):
                   linkStyle=Undefined, matrixExtent=Undefined, mouseOver=Undefined, outline=Undefined,
                   outlineWidth=Undefined, select=Undefined, textAnchor=Undefined,
                   textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                  textStrokeWidth=Undefined, **kwds) -> T:
+                  textStrokeWidth=Undefined, withinLinkVerticalLines=Undefined, **kwds) -> T:
         """Set the track's mark to 'area'
     
         For information on additional arguments, see :class:`Style`
@@ -83,7 +85,8 @@ class MarkMethodMixin(object):
                     linkStyle=linkStyle, matrixExtent=matrixExtent, mouseOver=mouseOver,
                     outline=outline, outlineWidth=outlineWidth, select=select, textAnchor=textAnchor,
                     textFontSize=textFontSize, textFontWeight=textFontWeight, textStroke=textStroke,
-                    textStrokeWidth=textStrokeWidth, **kwds)
+                    textStrokeWidth=textStrokeWidth, withinLinkVerticalLines=withinLinkVerticalLines,
+                    **kwds)
         copy = self.copy()
         copy.mark = "area"
         if any(val is not Undefined for val in kwds.values()):
@@ -96,7 +99,8 @@ class MarkMethodMixin(object):
                  linePattern=Undefined, linkConnectionType=Undefined, linkMinHeight=Undefined,
                  linkStyle=Undefined, matrixExtent=Undefined, mouseOver=Undefined, outline=Undefined,
                  outlineWidth=Undefined, select=Undefined, textAnchor=Undefined, textFontSize=Undefined,
-                 textFontWeight=Undefined, textStroke=Undefined, textStrokeWidth=Undefined, **kwds) -> T:
+                 textFontWeight=Undefined, textStroke=Undefined, textStrokeWidth=Undefined,
+                 withinLinkVerticalLines=Undefined, **kwds) -> T:
         """Set the track's mark to 'bar'
     
         For information on additional arguments, see :class:`Style`
@@ -109,7 +113,8 @@ class MarkMethodMixin(object):
                     linkStyle=linkStyle, matrixExtent=matrixExtent, mouseOver=mouseOver,
                     outline=outline, outlineWidth=outlineWidth, select=select, textAnchor=textAnchor,
                     textFontSize=textFontSize, textFontWeight=textFontWeight, textStroke=textStroke,
-                    textStrokeWidth=textStrokeWidth, **kwds)
+                    textStrokeWidth=textStrokeWidth, withinLinkVerticalLines=withinLinkVerticalLines,
+                    **kwds)
         copy = self.copy()
         copy.mark = "bar"
         if any(val is not Undefined for val in kwds.values()):
@@ -123,7 +128,7 @@ class MarkMethodMixin(object):
                   linkStyle=Undefined, matrixExtent=Undefined, mouseOver=Undefined, outline=Undefined,
                   outlineWidth=Undefined, select=Undefined, textAnchor=Undefined,
                   textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                  textStrokeWidth=Undefined, **kwds) -> T:
+                  textStrokeWidth=Undefined, withinLinkVerticalLines=Undefined, **kwds) -> T:
         """Set the track's mark to 'rect'
     
         For information on additional arguments, see :class:`Style`
@@ -136,7 +141,8 @@ class MarkMethodMixin(object):
                     linkStyle=linkStyle, matrixExtent=matrixExtent, mouseOver=mouseOver,
                     outline=outline, outlineWidth=outlineWidth, select=select, textAnchor=textAnchor,
                     textFontSize=textFontSize, textFontWeight=textFontWeight, textStroke=textStroke,
-                    textStrokeWidth=textStrokeWidth, **kwds)
+                    textStrokeWidth=textStrokeWidth, withinLinkVerticalLines=withinLinkVerticalLines,
+                    **kwds)
         copy = self.copy()
         copy.mark = "rect"
         if any(val is not Undefined for val in kwds.values()):
@@ -150,7 +156,7 @@ class MarkMethodMixin(object):
                   linkStyle=Undefined, matrixExtent=Undefined, mouseOver=Undefined, outline=Undefined,
                   outlineWidth=Undefined, select=Undefined, textAnchor=Undefined,
                   textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                  textStrokeWidth=Undefined, **kwds) -> T:
+                  textStrokeWidth=Undefined, withinLinkVerticalLines=Undefined, **kwds) -> T:
         """Set the track's mark to 'text'
     
         For information on additional arguments, see :class:`Style`
@@ -163,7 +169,8 @@ class MarkMethodMixin(object):
                     linkStyle=linkStyle, matrixExtent=matrixExtent, mouseOver=mouseOver,
                     outline=outline, outlineWidth=outlineWidth, select=select, textAnchor=textAnchor,
                     textFontSize=textFontSize, textFontWeight=textFontWeight, textStroke=textStroke,
-                    textStrokeWidth=textStrokeWidth, **kwds)
+                    textStrokeWidth=textStrokeWidth, withinLinkVerticalLines=withinLinkVerticalLines,
+                    **kwds)
         copy = self.copy()
         copy.mark = "text"
         if any(val is not Undefined for val in kwds.values()):
@@ -177,7 +184,8 @@ class MarkMethodMixin(object):
                         linkStyle=Undefined, matrixExtent=Undefined, mouseOver=Undefined,
                         outline=Undefined, outlineWidth=Undefined, select=Undefined,
                         textAnchor=Undefined, textFontSize=Undefined, textFontWeight=Undefined,
-                        textStroke=Undefined, textStrokeWidth=Undefined, **kwds) -> T:
+                        textStroke=Undefined, textStrokeWidth=Undefined,
+                        withinLinkVerticalLines=Undefined, **kwds) -> T:
         """Set the track's mark to 'withinLink'
     
         For information on additional arguments, see :class:`Style`
@@ -190,7 +198,8 @@ class MarkMethodMixin(object):
                     linkStyle=linkStyle, matrixExtent=matrixExtent, mouseOver=mouseOver,
                     outline=outline, outlineWidth=outlineWidth, select=select, textAnchor=textAnchor,
                     textFontSize=textFontSize, textFontWeight=textFontWeight, textStroke=textStroke,
-                    textStrokeWidth=textStrokeWidth, **kwds)
+                    textStrokeWidth=textStrokeWidth, withinLinkVerticalLines=withinLinkVerticalLines,
+                    **kwds)
         copy = self.copy()
         copy.mark = "withinLink"
         if any(val is not Undefined for val in kwds.values()):
@@ -204,7 +213,8 @@ class MarkMethodMixin(object):
                          linkStyle=Undefined, matrixExtent=Undefined, mouseOver=Undefined,
                          outline=Undefined, outlineWidth=Undefined, select=Undefined,
                          textAnchor=Undefined, textFontSize=Undefined, textFontWeight=Undefined,
-                         textStroke=Undefined, textStrokeWidth=Undefined, **kwds) -> T:
+                         textStroke=Undefined, textStrokeWidth=Undefined,
+                         withinLinkVerticalLines=Undefined, **kwds) -> T:
         """Set the track's mark to 'betweenLink'
     
         For information on additional arguments, see :class:`Style`
@@ -217,7 +227,8 @@ class MarkMethodMixin(object):
                     linkStyle=linkStyle, matrixExtent=matrixExtent, mouseOver=mouseOver,
                     outline=outline, outlineWidth=outlineWidth, select=select, textAnchor=textAnchor,
                     textFontSize=textFontSize, textFontWeight=textFontWeight, textStroke=textStroke,
-                    textStrokeWidth=textStrokeWidth, **kwds)
+                    textStrokeWidth=textStrokeWidth, withinLinkVerticalLines=withinLinkVerticalLines,
+                    **kwds)
         copy = self.copy()
         copy.mark = "betweenLink"
         if any(val is not Undefined for val in kwds.values()):
@@ -231,7 +242,7 @@ class MarkMethodMixin(object):
                   linkStyle=Undefined, matrixExtent=Undefined, mouseOver=Undefined, outline=Undefined,
                   outlineWidth=Undefined, select=Undefined, textAnchor=Undefined,
                   textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                  textStrokeWidth=Undefined, **kwds) -> T:
+                  textStrokeWidth=Undefined, withinLinkVerticalLines=Undefined, **kwds) -> T:
         """Set the track's mark to 'rule'
     
         For information on additional arguments, see :class:`Style`
@@ -244,7 +255,8 @@ class MarkMethodMixin(object):
                     linkStyle=linkStyle, matrixExtent=matrixExtent, mouseOver=mouseOver,
                     outline=outline, outlineWidth=outlineWidth, select=select, textAnchor=textAnchor,
                     textFontSize=textFontSize, textFontWeight=textFontWeight, textStroke=textStroke,
-                    textStrokeWidth=textStrokeWidth, **kwds)
+                    textStrokeWidth=textStrokeWidth, withinLinkVerticalLines=withinLinkVerticalLines,
+                    **kwds)
         copy = self.copy()
         copy.mark = "rule"
         if any(val is not Undefined for val in kwds.values()):
@@ -259,7 +271,7 @@ class MarkMethodMixin(object):
                           mouseOver=Undefined, outline=Undefined, outlineWidth=Undefined,
                           select=Undefined, textAnchor=Undefined, textFontSize=Undefined,
                           textFontWeight=Undefined, textStroke=Undefined, textStrokeWidth=Undefined,
-                          **kwds) -> T:
+                          withinLinkVerticalLines=Undefined, **kwds) -> T:
         """Set the track's mark to 'triangleLeft'
     
         For information on additional arguments, see :class:`Style`
@@ -272,7 +284,8 @@ class MarkMethodMixin(object):
                     linkStyle=linkStyle, matrixExtent=matrixExtent, mouseOver=mouseOver,
                     outline=outline, outlineWidth=outlineWidth, select=select, textAnchor=textAnchor,
                     textFontSize=textFontSize, textFontWeight=textFontWeight, textStroke=textStroke,
-                    textStrokeWidth=textStrokeWidth, **kwds)
+                    textStrokeWidth=textStrokeWidth, withinLinkVerticalLines=withinLinkVerticalLines,
+                    **kwds)
         copy = self.copy()
         copy.mark = "triangleLeft"
         if any(val is not Undefined for val in kwds.values()):
@@ -287,7 +300,7 @@ class MarkMethodMixin(object):
                            mouseOver=Undefined, outline=Undefined, outlineWidth=Undefined,
                            select=Undefined, textAnchor=Undefined, textFontSize=Undefined,
                            textFontWeight=Undefined, textStroke=Undefined, textStrokeWidth=Undefined,
-                           **kwds) -> T:
+                           withinLinkVerticalLines=Undefined, **kwds) -> T:
         """Set the track's mark to 'triangleRight'
     
         For information on additional arguments, see :class:`Style`
@@ -300,7 +313,8 @@ class MarkMethodMixin(object):
                     linkStyle=linkStyle, matrixExtent=matrixExtent, mouseOver=mouseOver,
                     outline=outline, outlineWidth=outlineWidth, select=select, textAnchor=textAnchor,
                     textFontSize=textFontSize, textFontWeight=textFontWeight, textStroke=textStroke,
-                    textStrokeWidth=textStrokeWidth, **kwds)
+                    textStrokeWidth=textStrokeWidth, withinLinkVerticalLines=withinLinkVerticalLines,
+                    **kwds)
         copy = self.copy()
         copy.mark = "triangleRight"
         if any(val is not Undefined for val in kwds.values()):
@@ -315,7 +329,7 @@ class MarkMethodMixin(object):
                             mouseOver=Undefined, outline=Undefined, outlineWidth=Undefined,
                             select=Undefined, textAnchor=Undefined, textFontSize=Undefined,
                             textFontWeight=Undefined, textStroke=Undefined, textStrokeWidth=Undefined,
-                            **kwds) -> T:
+                            withinLinkVerticalLines=Undefined, **kwds) -> T:
         """Set the track's mark to 'triangleBottom'
     
         For information on additional arguments, see :class:`Style`
@@ -328,7 +342,8 @@ class MarkMethodMixin(object):
                     linkStyle=linkStyle, matrixExtent=matrixExtent, mouseOver=mouseOver,
                     outline=outline, outlineWidth=outlineWidth, select=select, textAnchor=textAnchor,
                     textFontSize=textFontSize, textFontWeight=textFontWeight, textStroke=textStroke,
-                    textStrokeWidth=textStrokeWidth, **kwds)
+                    textStrokeWidth=textStrokeWidth, withinLinkVerticalLines=withinLinkVerticalLines,
+                    **kwds)
         copy = self.copy()
         copy.mark = "triangleBottom"
         if any(val is not Undefined for val in kwds.values()):
@@ -342,7 +357,7 @@ class MarkMethodMixin(object):
                    linkStyle=Undefined, matrixExtent=Undefined, mouseOver=Undefined, outline=Undefined,
                    outlineWidth=Undefined, select=Undefined, textAnchor=Undefined,
                    textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                   textStrokeWidth=Undefined, **kwds) -> T:
+                   textStrokeWidth=Undefined, withinLinkVerticalLines=Undefined, **kwds) -> T:
         """Set the track's mark to 'brush'
     
         For information on additional arguments, see :class:`Style`
@@ -355,7 +370,8 @@ class MarkMethodMixin(object):
                     linkStyle=linkStyle, matrixExtent=matrixExtent, mouseOver=mouseOver,
                     outline=outline, outlineWidth=outlineWidth, select=select, textAnchor=textAnchor,
                     textFontSize=textFontSize, textFontWeight=textFontWeight, textStroke=textStroke,
-                    textStrokeWidth=textStrokeWidth, **kwds)
+                    textStrokeWidth=textStrokeWidth, withinLinkVerticalLines=withinLinkVerticalLines,
+                    **kwds)
         copy = self.copy()
         copy.mark = "brush"
         if any(val is not Undefined for val in kwds.values()):
@@ -369,7 +385,7 @@ class MarkMethodMixin(object):
                     linkStyle=Undefined, matrixExtent=Undefined, mouseOver=Undefined, outline=Undefined,
                     outlineWidth=Undefined, select=Undefined, textAnchor=Undefined,
                     textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                    textStrokeWidth=Undefined, **kwds) -> T:
+                    textStrokeWidth=Undefined, withinLinkVerticalLines=Undefined, **kwds) -> T:
         """Set the track's mark to 'header'
     
         For information on additional arguments, see :class:`Style`
@@ -382,7 +398,8 @@ class MarkMethodMixin(object):
                     linkStyle=linkStyle, matrixExtent=matrixExtent, mouseOver=mouseOver,
                     outline=outline, outlineWidth=outlineWidth, select=select, textAnchor=textAnchor,
                     textFontSize=textFontSize, textFontWeight=textFontWeight, textStroke=textStroke,
-                    textStrokeWidth=textStrokeWidth, **kwds)
+                    textStrokeWidth=textStrokeWidth, withinLinkVerticalLines=withinLinkVerticalLines,
+                    **kwds)
         copy = self.copy()
         copy.mark = "header"
         if any(val is not Undefined for val in kwds.values()):

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -411,7 +411,7 @@ def generate_mark_mixin(schemafile: pathlib.Path, mark_enum: str, style_def: str
 
 def main(skip_download: Optional[bool] = False):
     library = "gosling.js"
-    version = "v0.9.23"
+    version = "v0.9.28"
 
     schemapath = here.parent / ".." / "gosling" / "schema"
     schemafile = download_schemafile(


### PR DESCRIPTION
~- chore: migrate build system to `hatch`~
~- run `tools/generate_schema_wrappers.py`~
~- chore: update GH Actions~
~- chore: bump higlass to v1.12~

Things seem to be working ... but some behavior is deprecated? @sehilyi the brushes in this example not longer link with the brushes on the right:

https://user-images.githubusercontent.com/24403730/223539685-f52538d2-b0c0-422c-99ef-2cc14f1dc898.mov

Note: the project now uses `hatchling` instead of `setuptools` for a build system. This is the new modern standard for python, and integrates well with the `hatch` CLI. `hatch` is like `npm`/`yarn`/`pnpm` but for python projects. You can install it globally on your system with `pipx`.

```sh
pipx install hatch
```

```sh
cd gos
# commands defined in pyproject.toml
hatch run test
hatch run docs
```

```sh
hatch shell # enter a virtual environment with gosling installed and all development deps (like conda activate)
jupyter lab # open examples
```


