### PR TITLE
refactor: revert ESM imports until gosling.js is more stable

### DIFF
--- a/gosling/display.py
+++ b/gosling/display.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 import jinja2
-from gosling.plugin_registry import PluginRegistry
 
+from gosling.plugin_registry import PluginRegistry
 from gosling.schema import SCHEMA_VERSION, THEMES
 
 HTML_TEMPLATE = jinja2.Template(
@@ -14,17 +14,56 @@ HTML_TEMPLATE = jinja2.Template(
 <html>
 <head>
   <style>.error { color: red; }</style>
-  <link rel="stylesheet" href="{{ deps.css_url }}">
+  <link rel="stylesheet" href="{{ higlass_css_url }}">
 </head>
 <body>
   <div id="{{ output_div }}"></div>
   <script type="module">
-    import * as gosling from "{{ deps.esm_url }}";
-    let el = document.querySelector('#{{ output_div }}');
-    let spec = {{ spec }};
-    let opts = {{ embed_options }};
-    gosling.embed(el, spec, opts).catch(err => {
-        el.innerHTML = `\
+    async function loadScript(src) {
+        return new Promise(resolve => {
+            const script = document.createElement('script');
+            script.onload = resolve;
+            script.src = src;
+            script.async = false;
+            document.head.appendChild(script);
+        });
+    }
+    async function loadGosling() {
+        // Manually load scripts from window namespace since requirejs might not be
+        // available in all browser environments.
+        // https://github.com/DanielHreben/requirejs-toggle
+        if (!window.gosling) {
+            // https://github.com/DanielHreben/requirejs-toggle
+            window.__requirejsToggleBackup = {
+                define: window.define,
+                require: window.require,
+                requirejs: window.requirejs,
+            };
+            for (const field of Object.keys(window.__requirejsToggleBackup)) {
+                window[field] = undefined;
+            }
+            // load dependencies sequentially
+            const sources = [
+                "{{ react_url }}",
+                "{{ react_dom_url }}",
+                "{{ pixijs_url }}",
+                "{{ higlass_js_url }}",
+                "{{ gosling_url }}",
+            ];
+            for (const src of sources) await loadScript(src);
+            // restore requirejs after scripts have loaded
+            Object.assign(window, window.__requirejsToggleBackup);
+            delete window.__requirejsToggleBackup;
+        }
+        return window.gosling;
+    };
+    var el = document.getElementById('{{ output_div }}');
+    var spec = {{ spec }};
+    var opt = {{ embed_options }};
+    loadGosling()
+        .then(gosling => gosling.embed(el, spec, opt))
+        .catch(err => {
+            el.innerHTML = `\
 <div class="error">
     <p>JavaScript Error: ${error.message}</p>
     <p>This usually means there's a typo in your Gosling specification. See the javascript console for the full traceback.</p>
@@ -41,30 +80,29 @@ GoslingSpec = Dict[str, Any]
 
 
 @dataclass
-class GoslingDeps:
-    esm_url: str
-    css_url: str
+class GoslingBundle:
+    react: str
+    react_dom: str
+    pixijs: str
+    higlass_js: str
+    higlass_css: str
+    gosling: str
 
 
 def get_display_dependencies(
     gosling_version: str = SCHEMA_VERSION.lstrip("v"),
-    higlass_version: str = "~1.11",
+    higlass_version: str = "1.11",
     react_version: str = "17",
     pixijs_version: str = "6",
-) -> GoslingDeps:
-    base = "https://esm.sh"
-    deps = ",".join(
-        f"{name}@{version}"
-        for name, version in (
-            ("react-dom", react_version),
-            ("react", react_version),
-            ("pixi.js", pixijs_version),
-            ("higlass", higlass_version),
-        )
-    )
-    return GoslingDeps(
-        esm_url=f"{base}/gosling.js@{gosling_version}?bundle&deps={deps}",
-        css_url=f"{base}/higlass@{higlass_version}/dist/hglib.css",
+    base_url: str = "https://unpkg.com",
+) -> GoslingBundle:
+    return GoslingBundle(
+        react=f"{ base_url }/react@{ react_version }/umd/react.production.min.js",
+        react_dom=f"{ base_url }/react-dom@{ react_version }/umd/react-dom.production.min.js",
+        pixijs=f"{ base_url }/pixi.js@{ pixijs_version }/dist/browser/pixi.min.js",
+        higlass_js=f"{ base_url }/higlass@{ higlass_version }/dist/hglib.js",
+        higlass_css=f"{ base_url }/higlass@{ higlass_version }/dist/hglib.css",
+        gosling=f"{ base_url }/gosling.js@{ gosling_version }/dist/gosling.js",
     )
 
 
@@ -75,13 +113,19 @@ def spec_to_html(
     **kwargs,
 ):
     embed_options = embed_options or dict(padding=0, theme=themes.get())
+    deps = get_display_dependencies(**kwargs)
+
     return HTML_TEMPLATE.render(
         spec=json.dumps(spec),
         embed_options=json.dumps(embed_options),
         output_div=output_div,
-        deps=get_display_dependencies(**kwargs),
+        react_url=deps.react,
+        react_dom_url=deps.react_dom,
+        pixijs_url=deps.pixijs,
+        higlass_js_url=deps.higlass_js,
+        higlass_css_url=deps.higlass_css,
+        gosling_url=deps.gosling,
     )
-
 
 class Renderer:
     def __init__(self, output_div: str = "jupyter-gosling-{}", **kwargs: Any):
@@ -103,6 +147,7 @@ class HTMLRenderer(Renderer):
         html = spec_to_html(spec=spec, output_div=self.output_div, **kwargs)
         return {"text/html": html}
 
+
 renderers = PluginRegistry[Renderer]("gosling.renderer")
 renderers.register("default", HTMLRenderer())
 renderers.enable("default")
@@ -112,4 +157,4 @@ CustomTheme = Dict[str, Any]
 themes = PluginRegistry[CustomTheme]("gosling.theme")
 for theme in THEMES:
     # Add builtin string themes
-    themes.register(theme, theme) # type: ignore
+    themes.register(theme, theme)  # type: ignore

--- a/gosling/sphinxext/plot.py
+++ b/gosling/sphinxext/plot.py
@@ -15,10 +15,11 @@ TEMPLATE = jinja2.Template(
 <div id="{{ div_id }}">
 <script>
   document.addEventListener("DOMContentLoaded", function(event) {
-      let spec = {{ spec }};
-      let el = document.querySelector('#{{ div_id }}');
-      gosling.embed(el, spec, { padding: 0 }).catch(console.error);
+      var spec = {{ spec }};
       console.log(spec);
+      var opt = { padding: 0 };
+      var el = document.querySelector('#{{ div_id }}');
+      gosling.embed(el, spec, opt).catch(console.err);
   });
 </script>
 </div>
@@ -112,19 +113,22 @@ def depart_gosling_plot(self, node):
 
 
 def builder_inited(app):
-    app.add_css_file(app.config.css_url)
-    # inline script that adds `gosling` global
-    app.add_js_file(
-        filename=None,
-        type="module",
-        body=f"import * as gosling from '{app.config.esm_url}';globalThis.gosling = gosling;",
-    )
+    app.add_css_file(app.config.higlass_css_url)
+    app.add_js_file(app.config.react_url)
+    app.add_js_file(app.config.reactdom_url)
+    app.add_js_file(app.config.pixi_url)
+    app.add_js_file(app.config.higlass_js_url)
+    app.add_js_file(app.config.gosling_url)
 
 
 def setup(app):
     deps = get_display_dependencies()
-    app.add_config_value("esm_url", deps.esm_url, "html")
-    app.add_config_value("css_url", deps.css_url, "html")
+    app.add_config_value("react_url", deps.react, "html")
+    app.add_config_value("reactdom_url", deps.react_dom, "html")
+    app.add_config_value("pixi_url", deps.pixijs, "html")
+    app.add_config_value("higlass_js_url", deps.higlass_js, "html")
+    app.add_config_value("higlass_css_url", deps.higlass_css, "html")
+    app.add_config_value("gosling_url", deps.gosling, "html")
 
     app.add_directive("gosling-plot", GoslingPlotDirective)
     app.add_node(gosling_plot, html=(html_visit_gosling_plot, depart_gosling_plot))


### PR DESCRIPTION
Reverts the changes from #108. Gosling.js in it's current state isn't stable enough to use esm.sh as a CDN. We need finer control over dependencies at the moment, but in the future should strive towards loading gosling with ESM.
