### PR TITLE
feat: Upgrade to Gosling v0.9.31

### DIFF
--- a/doc/user_guide/API.rst
+++ b/doc/user_guide/API.rst
@@ -77,6 +77,7 @@ Low-Level Schema Wrappers
    Assembly
    AxisPosition
    BamData
+   BedData
    BeddbData
    BigWigData
    BinAggregate

--- a/gosling/__init__.py
+++ b/gosling/__init__.py
@@ -10,6 +10,7 @@ from gosling.api import *
 from gosling.data import (
     GoslingDataServer,
     bam,
+    bed,
     beddb,
     bigwig,
     csv,

--- a/gosling/data/__init__.py
+++ b/gosling/data/__init__.py
@@ -135,6 +135,7 @@ def json(values: list[dict[str, typing.Any]], **kwargs):
 bam = _create_loader("bam")
 csv = _create_loader("csv")
 bigwig = _create_loader("bigwig")
+bed = _create_loader("bed")
 
 # tileset resources
 beddb = _create_loader("beddb", tilesets.beddb)

--- a/gosling/schema/__init__.py
+++ b/gosling/schema/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from .core import *
 from .channels import *
-SCHEMA_VERSION = 'v0.9.30'
-SCHEMA_URL = 'https://raw.githubusercontent.com/gosling-lang/gosling.js/v0.9.30/schema/gosling.schema.json'
+SCHEMA_VERSION = 'v0.9.31'
+SCHEMA_URL = 'https://raw.githubusercontent.com/gosling-lang/gosling.js/v0.9.31/schema/gosling.schema.json'
 THEMES = {'dark', 'ensembl', 'excel', 'ggplot', 'google', 'igv', 'jbrowse', 'light', 'ucsc', 'warm', 'washu'}

--- a/gosling/schema/__init__.py
+++ b/gosling/schema/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from .core import *
 from .channels import *
-SCHEMA_VERSION = 'v0.9.29'
-SCHEMA_URL = 'https://raw.githubusercontent.com/gosling-lang/gosling.js/v0.9.29/schema/gosling.schema.json'
+SCHEMA_VERSION = 'v0.9.30'
+SCHEMA_URL = 'https://raw.githubusercontent.com/gosling-lang/gosling.js/v0.9.30/schema/gosling.schema.json'
 THEMES = {'dark', 'ensembl', 'excel', 'ggplot', 'google', 'igv', 'jbrowse', 'light', 'ucsc', 'warm', 'washu'}

--- a/gosling/schema/core.py
+++ b/gosling/schema/core.py
@@ -174,9 +174,9 @@ class Color(ChannelDeep):
 class DataDeep(GoslingSchema):
     """DataDeep schema wrapper
 
-    anyOf(:class:`JsonData`, :class:`CsvData`, :class:`BigWigData`, :class:`MultivecData`,
-    :class:`BeddbData`, :class:`VectorData`, :class:`MatrixData`, :class:`BamData`,
-    :class:`VcfData`)
+    anyOf(:class:`JsonData`, :class:`CsvData`, :class:`BedData`, :class:`BigWigData`,
+    :class:`MultivecData`, :class:`BeddbData`, :class:`VectorData`, :class:`MatrixData`,
+    :class:`BamData`, :class:`VcfData`)
     """
     _schema = {'$ref': '#/definitions/DataDeep'}
     _rootschema = GoslingSchema._rootschema
@@ -221,6 +221,39 @@ class BamData(DataDeep):
                                       extractJunction=extractJunction,
                                       junctionMinCoverage=junctionMinCoverage, loadMates=loadMates,
                                       maxInsertSize=maxInsertSize, **kwds)
+
+
+class BedData(DataDeep):
+    """BedData schema wrapper
+
+    Mapping(required=[type, url, indexUrl])
+    BED file format
+
+    Attributes
+    ----------
+
+    indexUrl : string
+        Specify the URL address of the data file index.
+    type : string
+
+    url : string
+        Specify the URL address of the data file.
+    customFields : List(string)
+        An array of strings, where each string is the name of a non-standard field in the
+        BED file. If there are `n` custom fields, we assume that the last `n` columns of the
+        BED file correspond to the custom fields.
+    sampleLength : float
+        Specify the number of rows loaded from the URL.
+
+        __Default:__ `1000`
+    """
+    _schema = {'$ref': '#/definitions/BedData'}
+    _rootschema = GoslingSchema._rootschema
+
+    def __init__(self, indexUrl=Undefined, type=Undefined, url=Undefined, customFields=Undefined,
+                 sampleLength=Undefined, **kwds):
+        super(BedData, self).__init__(indexUrl=indexUrl, type=type, url=url, customFields=customFields,
+                                      sampleLength=sampleLength, **kwds)
 
 
 class BeddbData(DataDeep):
@@ -309,7 +342,8 @@ class CsvData(DataDeep):
     chromosomeField : string
         Specify the name of chromosome data fields.
     chromosomePrefix : string
-        experimental
+        Specify the chromosome prefix if chromosomes are denoted using a prefix besides
+        "chr" or a number
     genomicFields : List(string)
         Specify the name of genomic data fields.
     genomicFieldsToConvert : List(Mapping(required=[chromosomeField, genomicFields]))

--- a/gosling/schema/gosling-schema.json
+++ b/gosling/schema/gosling-schema.json
@@ -101,6 +101,41 @@
       ],
       "type": "object"
     },
+    "BedData": {
+      "additionalProperties": false,
+      "description": "BED file format",
+      "properties": {
+        "customFields": {
+          "description": "An array of strings, where each string is the name of a non-standard field in the BED file. If there are `n` custom fields, we assume that the last `n` columns of the BED file correspond to the custom fields.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "indexUrl": {
+          "description": "Specify the URL address of the data file index.",
+          "type": "string"
+        },
+        "sampleLength": {
+          "description": "Specify the number of rows loaded from the URL.\n\n__Default:__ `1000`",
+          "type": "number"
+        },
+        "type": {
+          "const": "bed",
+          "type": "string"
+        },
+        "url": {
+          "description": "Specify the URL address of the data file.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url",
+        "indexUrl"
+      ],
+      "type": "object"
+    },
     "BeddbData": {
       "additionalProperties": false,
       "description": "Regular BED or similar files can be pre-aggregated for the scalable data exploration. Find our more about this format at [HiGlass Docs](https://docs.higlass.io/data_preparation.html#bed-files).",
@@ -420,7 +455,7 @@
           "type": "string"
         },
         "chromosomePrefix": {
-          "description": "experimental",
+          "description": "Specify the chromosome prefix if chromosomes are denoted using a prefix besides \"chr\" or a number",
           "type": "string"
         },
         "genomicFields": {
@@ -494,6 +529,9 @@
         },
         {
           "$ref": "#/definitions/CsvData"
+        },
+        {
+          "$ref": "#/definitions/BedData"
         },
         {
           "$ref": "#/definitions/BigWigData"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,4 @@ features = ["dev", "all"]
 test = "pytest --ignore gosling/examples --ignore tools/altair --doctest-modules gosling"
 clean = "rm -rf doc/_build doc/user_guide/generated/ doc/gallery"
 docs = "sphinx-build -b html doc dist"
+generate-schema-wrapper = "python tools/generate_schema_wrapper.py"

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -411,7 +411,7 @@ def generate_mark_mixin(schemafile: pathlib.Path, mark_enum: str, style_def: str
 
 def main(skip_download: Optional[bool] = False):
     library = "gosling.js"
-    version = "v0.9.30"
+    version = "v0.9.31"
 
     schemapath = here.parent / ".." / "gosling" / "schema"
     schemafile = download_schemafile(

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -411,7 +411,7 @@ def generate_mark_mixin(schemafile: pathlib.Path, mark_enum: str, style_def: str
 
 def main(skip_download: Optional[bool] = False):
     library = "gosling.js"
-    version = "v0.9.29"
+    version = "v0.9.30"
 
     schemapath = here.parent / ".." / "gosling" / "schema"
     schemafile = download_schemafile(


### PR DESCRIPTION
Changes:

- Bumps Gosling.js to v0.9.31
- adds `gos.bed` as a top-level API

TODO:

Need to test out some BED examples. I'm noticing that BED only seems to work for indexed BED files? If  BED file isn't indexed, should users prefer the csv loader? @sehilyi @etowahadams 
