### PR TITLE
Allow specifying a port for local data served by `GoslingDataServer`

### DIFF
--- a/gosling/data/__init__.py
+++ b/gosling/data/__init__.py
@@ -108,18 +108,18 @@ def _create_loader(
     type_: str,
     create_ts: typing.Callable[[pathlib.Path], tilesets.Tileset] | None = None
 ):
-    def load(url: pathlib.Path | str, **kwargs):
+    def load(url: pathlib.Path | str, port: int | None = None, **kwargs):
         """Adds resource to data_server if local file is detected."""
         fp = pathlib.Path(url)
         if fp.is_file():
             data = create_ts(fp) if create_ts else fp
-            url = data_server(data)
+            url = data_server(data, port=port)
 
         # bam's index file url
         if "indexUrl" in kwargs:
             fp = pathlib.Path(kwargs["indexUrl"])
             if fp.is_file():
-                kwargs["indexUrl"] = data_server(fp)
+                kwargs["indexUrl"] = data_server(fp, port=port)
 
         return dict(type=type_, url=str(url), **kwargs)
 


### PR DESCRIPTION
Add a `port` keyword argument to allow the user to specify the port to be used by `GoslingDataServer`.
The class already supports it and [has it in its `__call__` signature](https://github.com/gosling-lang/gos/blob/c88a433574b5f5f7bac5f06419b55fda5147672e/gosling/data/__init__.py#L72), but the [loader functions don't](https://github.com/gosling-lang/gos/blob/c88a433574b5f5f7bac5f06419b55fda5147672e/gosling/data/__init__.py#L111). 