### PR TITLE
fix: Provide uid on tileset

### DIFF
--- a/gosling/data/__init__.py
+++ b/gosling/data/__init__.py
@@ -104,9 +104,10 @@ class GoslingDataServer:
 
 data_server = GoslingDataServer()
 
+
 def _create_loader(
     type_: str,
-    create_ts: typing.Callable[[pathlib.Path], tilesets.Tileset] | None = None
+    create_ts: typing.Callable[[pathlib.Path], tilesets.Tileset] | None = None,
 ):
     def load(url: pathlib.Path | str, **kwargs):
         """Adds resource to data_server if local file is detected."""

--- a/gosling/data/_tilesets.py
+++ b/gosling/data/_tilesets.py
@@ -4,14 +4,23 @@ import functools
 import pathlib
 import typing
 from dataclasses import dataclass
+import hashlib
 
 
 @dataclass(frozen=True)
 class Tileset:
     filepath: pathlib.Path
-    tiles: typing.Callable[[typing.Sequence[str]], list[typing.Any]]
+    tiles_impl: typing.Callable[[typing.Sequence[str]], list[typing.Any]]
     info: typing.Callable[[], typing.Any]
+    uid: str
     type: None | str = None
+
+    def tiles(self, tile_ids: typing.Sequence[str]) -> list[typing.Any]:
+        return self.tiles_impl(tile_ids)
+
+
+def create_uid(filepath: pathlib.Path) -> str:
+    return hashlib.md5(str(filepath).encode()).hexdigest()[0:8]
 
 
 def beddb(filepath: pathlib.Path):
@@ -25,8 +34,9 @@ def beddb(filepath: pathlib.Path):
     return Tileset(
         filepath=filepath,
         type="beddb",
-        tiles=functools.partial(tiles, filepath),
+        tiles_impl=functools.partial(tiles, filepath),
         info=functools.partial(tileset_info, filepath),
+        uid=create_uid(filepath),
     )
 
 
@@ -41,8 +51,9 @@ def bigwig(filepath: pathlib.Path):
     return Tileset(
         filepath=filepath,
         type="bigwig",
-        tiles=functools.partial(tiles, filepath),
+        tiles_impl=functools.partial(tiles, filepath),
         info=functools.partial(tileset_info, filepath),
+        uid=create_uid(filepath),
     )
 
 
@@ -57,8 +68,9 @@ def multivec(filepath: pathlib.Path):
     return Tileset(
         filepath=filepath,
         type="multivec",
-        tiles=functools.partial(tiles, filepath),
+        tiles_impl=functools.partial(tiles, filepath),
         info=functools.partial(tileset_info, filepath),
+        uid=create_uid(filepath),
     )
 
 
@@ -73,6 +85,7 @@ def cooler(filepath: pathlib.Path):
     return Tileset(
         filepath=filepath,
         type="cooler",
-        tiles=functools.partial(tiles, filepath),
+        tiles_impl=functools.partial(tiles, filepath),
         info=functools.partial(tileset_info, filepath),
+        uid=create_uid(filepath),
     )


### PR DESCRIPTION
`uid` is missing on the tileset implementation when we upgraded to `servir`.
